### PR TITLE
Translation Code Structure Proposal

### DIFF
--- a/lib/scsi_defs.h
+++ b/lib/scsi_defs.h
@@ -803,6 +803,18 @@ struct UnmapBlockDescriptor {
 } ABSL_ATTRIBUTE_PACKED;
 static_assert(sizeof(UnmapBlockDescriptor) == 16);
 
+
+// SCSI Reference Manual Table 483
+// https://www.seagate.com/files/staticfiles/support/docs/manual/Interface%20manuals/100293068j.pdf
+struct SupportedVitalProductDataPages {
+  PeripheralQualifier peripheral_qualifier : 3;
+  PeripheralDeviceType peripheral_device_type : 5;
+  uint8_t page_code : 8;
+  uint8_t _reserved : 8;
+  uint8_t page_length : 8;
+  uint8_t supported_page_list[5]; // actually variable in length but so far all we need is 5...
+} ABSL_ATTRIBUTE_PACKED;
+
 }  // namespace scsi_defs
 
 #endif

--- a/lib/scsi_defs.h
+++ b/lib/scsi_defs.h
@@ -225,9 +225,9 @@ struct InquiryData {
   bool reserved_6 : 1;
   bool cmdque : 1;  // Command Management Model bit
   bool vs_2 : 1;    // vendor specific bit
-  uint64_t vendor_identification : 64;
+  char vendor_identification [8];
   uint8_t product_identification[16];
-  uint32_t product_revision_level : 32;
+  uint8_t product_revision_level[4];
   uint8_t vendor_specific_1[20];
   uint8_t reserved_7 : 4;
   uint8_t clocking : 2;

--- a/lib/scsi_defs.h
+++ b/lib/scsi_defs.h
@@ -803,17 +803,44 @@ struct UnmapBlockDescriptor {
 } ABSL_ATTRIBUTE_PACKED;
 static_assert(sizeof(UnmapBlockDescriptor) == 16);
 
-
 // SCSI Reference Manual Table 483
 // https://www.seagate.com/files/staticfiles/support/docs/manual/Interface%20manuals/100293068j.pdf
-struct SupportedVitalProductDataPages {
+struct SupportedVitalProductData {
   PeripheralQualifier peripheral_qualifier : 3;
   PeripheralDeviceType peripheral_device_type : 5;
   uint8_t page_code : 8;
   uint8_t _reserved : 8;
   uint8_t page_length : 8;
-  uint8_t supported_page_list[5]; // actually variable in length but so far all we need is 5...
+  uint8_t supported_page_list[10]; // TODO: actually variable in length
 } ABSL_ATTRIBUTE_PACKED;
+
+// SCSI Reference Manual Table 484
+// https://www.seagate.com/files/staticfiles/support/docs/manual/Interface%20manuals/100293068j.pdf
+struct UnitSerialNumber {
+  PeripheralQualifier peripheral_qualifier : 3;
+  PeripheralDeviceType peripheral_device_type : 5;
+  uint8_t page_code : 8;
+  uint8_t _reserved : 8;
+  uint8_t page_length : 8;
+  uint8_t product_serial_number[20]; // TODO: actually variable in length
+} ABSL_ATTRIBUTE_PACKED;
+
+// SCSI Reference Manual Table 460
+// https://www.seagate.com/files/staticfiles/support/docs/manual/Interface%20manuals/100293068j.pdf
+struct IdentificationDescriptor {
+  // TODO
+} ABSL_ATTRIBUTE_PACKED;
+
+// SCSI Reference Manual Table 459
+// https://www.seagate.com/files/staticfiles/support/docs/manual/Interface%20manuals/100293068j.pdf
+struct DeviceIdentificationVPD {
+  PeripheralQualifier peripheral_qualifier : 3;
+  PeripheralDeviceType peripheral_device_type : 5;
+  uint8_t page_code : 8;
+  uint8_t page_length : 8;
+  IdentificationDescriptor identification_descriptor_list[10]; // TODO: actually variable in length
+} ABSL_ATTRIBUTE_PACKED;
+
 
 }  // namespace scsi_defs
 

--- a/lib/scsi_defs.h
+++ b/lib/scsi_defs.h
@@ -811,7 +811,7 @@ struct SupportedVitalProductData {
   uint8_t page_code : 8;
   uint8_t _reserved : 8;
   uint8_t page_length : 8;
-  uint8_t supported_page_list[10]; // TODO: actually variable in length
+  uint8_t supported_page_list[256];
 } ABSL_ATTRIBUTE_PACKED;
 
 // SCSI Reference Manual Table 484
@@ -822,13 +822,23 @@ struct UnitSerialNumber {
   uint8_t page_code : 8;
   uint8_t _reserved : 8;
   uint8_t page_length : 8;
-  uint8_t product_serial_number[20]; // TODO: actually variable in length
+  uint8_t product_serial_number[256];
 } ABSL_ATTRIBUTE_PACKED;
+
 
 // SCSI Reference Manual Table 460
 // https://www.seagate.com/files/staticfiles/support/docs/manual/Interface%20manuals/100293068j.pdf
 struct IdentificationDescriptor {
-  // TODO
+  uint8_t protocol_identifier: 4;
+  uint8_t code_set: 4;
+  uint8_t piv : 1;
+  uint8_t _reserved1 : 1;
+  uint8_t association : 2;
+  uint8_t identifier_type : 4;
+  uint8_t _reserved2 : 8;
+  uint8_t identifier_length : 8;
+  uint8_t identifier[256];
+
 } ABSL_ATTRIBUTE_PACKED;
 
 // SCSI Reference Manual Table 459
@@ -838,7 +848,7 @@ struct DeviceIdentificationVPD {
   PeripheralDeviceType peripheral_device_type : 5;
   uint8_t page_code : 8;
   uint8_t page_length : 8;
-  IdentificationDescriptor identification_descriptor_list[10]; // TODO: actually variable in length
+  IdentificationDescriptor identification_descriptor_list[256];
 } ABSL_ATTRIBUTE_PACKED;
 
 

--- a/lib/scsi_defs.h
+++ b/lib/scsi_defs.h
@@ -225,7 +225,7 @@ struct InquiryData {
   bool reserved_6 : 1;
   bool cmdque : 1;  // Command Management Model bit
   bool vs_2 : 1;    // vendor specific bit
-  char vendor_identification [8];
+  char vendor_identification[8];
   uint8_t product_identification[16];
   uint8_t product_revision_level[4];
   uint8_t vendor_specific_1[20];
@@ -825,12 +825,11 @@ struct UnitSerialNumber {
   uint8_t product_serial_number[256];
 } ABSL_ATTRIBUTE_PACKED;
 
-
 // SCSI Reference Manual Table 460
 // https://www.seagate.com/files/staticfiles/support/docs/manual/Interface%20manuals/100293068j.pdf
 struct IdentificationDescriptor {
-  uint8_t protocol_identifier: 4;
-  uint8_t code_set: 4;
+  uint8_t protocol_identifier : 4;
+  uint8_t code_set : 4;
   uint8_t piv : 1;
   uint8_t _reserved1 : 1;
   uint8_t association : 2;
@@ -850,7 +849,6 @@ struct DeviceIdentificationVPD {
   uint8_t page_length : 8;
   IdentificationDescriptor identification_descriptor_list[256];
 } ABSL_ATTRIBUTE_PACKED;
-
 
 }  // namespace scsi_defs
 

--- a/lib/translate/BUILD
+++ b/lib/translate/BUILD
@@ -6,6 +6,7 @@ cc_library(
       "//third_party/spdk_defs:nvme_defs_lib",
       "//lib:scsi_defs_lib",
       "@com_google_absl//absl/base",
+      "@com_google_absl//absl/types:span"
   ],
   visibility = ["//visibility:public"],
 )

--- a/lib/translate/BUILD
+++ b/lib/translate/BUILD
@@ -1,0 +1,11 @@
+cc_library(
+  name = "inquiry_lib",
+  srcs = ["inquiry.cc"],
+  hdrs = ["inquiry.h"],
+  deps = [
+      "//third_party/spdk_defs:nvme_defs_lib",
+      "//lib:scsi_defs_lib",
+      "@com_google_absl//absl/base",
+  ],
+  visibility = ["//visibility:public"],
+)

--- a/lib/translate/inquiry.cc
+++ b/lib/translate/inquiry.cc
@@ -131,19 +131,42 @@ namespace inquiry {
 
         
         // check if nonzero
-        bool eui64_nz = false, nguid_nz = false;
-        for(int i = 0; i < 16; i++) {
-            if(identify_namespace_data.nguid[i] != 0) {
-                nguid_nz = true; break;
-            }
-        }
-        eui64_nz = identify_namespace_data.eui64 != 0;
+        bool nguid_nz = identify_namespace_data.nguid[0] || identify_namespace_data.nguid[1];
+        bool eui64_nz = identify_namespace_data.eui64;
         printf("e %d n %d\n", eui64_nz, nguid_nz);
         if(eui64_nz) {
             if(nguid_nz) {
                 // 6.1.3.1.1
                 // nguid
                 result.page_length = 40;
+                // char hex_string[17];
+                // sprintf(hex_string, "%llx", identify_namespace_data.nguid[0]);
+
+                // char formatted_hex_string[21];
+                // for(int i = 4; i < result.page_length; i+=5) {
+                //     formatted_hex_string[i] = '_';
+                // }
+
+                // int pos = 0;
+                // for(int i = 0; i < result.page_length - 1; i++) {
+                //     if(formatted_hex_string[i] != '_') {
+                //         formatted_hex_string[i] = hex_string[pos++];
+                //     }
+                // }
+                // formatted_hex_string[result.page_length - 1] = '_';
+
+                // memcpy(result.product_serial_number, formatted_hex_string, result.page_length);
+
+                // sprintf(hex_string, "%llx", identify_namespace_data.nguid[1]);
+                // pos = 0;
+                // for(int i = 0; i < result.page_length - 1; i++) {
+                //     if(formatted_hex_string[i] != '_') {
+                //         formatted_hex_string[i] = hex_string[pos++];
+                //     }
+                // }
+                // formatted_hex_string[result.page_length - 1] = '.';
+                // memcpy(&result.product_serial_number[20], formatted_hex_string, result.page_length);
+
             }
             else {
                 // 6.1.3.1.2

--- a/lib/translate/inquiry.cc
+++ b/lib/translate/inquiry.cc
@@ -17,7 +17,7 @@
 namespace inquiry {
     // Creates and validates a Inquiry Command struct
     std::optional<scsi_defs::InquiryCommand> raw_cmd_to_scsi_command(absl::Span<const uint32_t> raw_cmd) {
-        if (raw_cmd.length() == 0 || raw_cmd.data() == nullptr) {
+        if (raw_cmd.empty()) {
             printf("buffer is empty or nullptr\n");
             return std::nullopt;
         }
@@ -28,8 +28,9 @@ namespace inquiry {
             return std::nullopt;
         }
 
+        // printf("opcode is good, casting\n");
         // TODO: check invalid parameters in scsi_command
-        return std::make_optional(*reinterpret_cast<scsi_defs::InquiryCommand*>(raw_cmd[1]));
+        return std::make_optional(*reinterpret_cast<const scsi_defs::InquiryCommand*>(&raw_cmd[1]));
     }
 
     // Executes the NVME Identify Controller command

--- a/lib/translate/inquiry.cc
+++ b/lib/translate/inquiry.cc
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #include "inquiry.h"
-
+#include "string.h"
 namespace inquiry {
     // Creates and validates a Inquiry Command struct
     std::optional<scsi_defs::InquiryCommand> raw_cmd_to_scsi_command(absl::Span<const uint32_t> raw_cmd) {
@@ -71,11 +71,7 @@ namespace inquiry {
 
         // Shall be set to “NVMe” followed by 4 spaces: “NVMe “
         char NVME_VENDOR_IDENTIFICATION[9] = "NVMe    ";
-        for(int i = 0; i < 8; i++) {
-            result.vendor_identification <<= 8;
-            result.vendor_identification |= NVME_VENDOR_IDENTIFICATION[i];
-        }
-        // printf("%lux\n", result.vendor_identification);
+        strncpy(result.vendor_identification, NVME_VENDOR_IDENTIFICATION, 8);
 
         // Shall be set to the first 16 bytes of the Model Number (MN) field within the Identify Controller Data Structure
         for(int i = 0; i < 16; i++) {
@@ -84,8 +80,7 @@ namespace inquiry {
 
         // Shall be set to the first 4 bytes of the Firmware Revision (FR) field within the Identify Controller Data Structure
         for(int i = 0; i < 4; i++) {
-            result.product_revision_level <<= 8;
-            result.product_revision_level |= identify_controller_data.fr[i];
+            result.product_revision_level[i] = identify_controller_data.fr[i];
         }
         return result;
     }

--- a/lib/translate/inquiry.cc
+++ b/lib/translate/inquiry.cc
@@ -95,9 +95,9 @@ namespace inquiry {
         }
         return result;
     }
-    scsi_defs::SupportedVitalProductDataPages build_supported_vpd_pages_data()
+    scsi_defs::SupportedVitalProductData build_supported_vpd_pages_data()
     {
-        scsi_defs::SupportedVitalProductDataPages result = scsi_defs::SupportedVitalProductDataPages();
+        scsi_defs::SupportedVitalProductData result = scsi_defs::SupportedVitalProductData();
         result.peripheral_qualifier = scsi_defs::PeripheralQualifier::kPeripheralDeviceConnected;
         result.peripheral_device_type = scsi_defs::PeripheralDeviceType::kDirectAccessBlock;
 
@@ -125,7 +125,7 @@ namespace inquiry {
                 // Shall be supported by returning Supported VPD Pages data page to application client, refer to 6.1.2.
                 case 0x00:
                  {
-                    scsi_defs::SupportedVitalProductDataPages result = build_supported_vpd_pages_data();
+                    scsi_defs::SupportedVitalProductData result = build_supported_vpd_pages_data();
                     break;
                  }
                 // Shall be supported by returning Unit Serial Number data page to application client. Refer to 6.1.3.

--- a/lib/translate/inquiry.cc
+++ b/lib/translate/inquiry.cc
@@ -139,33 +139,24 @@ namespace inquiry {
                 // 6.1.3.1.1
                 // nguid
                 result.page_length = 40;
-                // char hex_string[17];
-                // sprintf(hex_string, "%llx", identify_namespace_data.nguid[0]);
+                char hex_string[33];
+                sprintf(hex_string, "%llx", identify_namespace_data.nguid[0]);
+                sprintf(&hex_string[16], "%llx", identify_namespace_data.nguid[1]);
 
-                // char formatted_hex_string[21];
-                // for(int i = 4; i < result.page_length; i+=5) {
-                //     formatted_hex_string[i] = '_';
-                // }
+                char formatted_hex_string[41];
+                for(int i = 4; i < result.page_length; i+=5) {
+                    formatted_hex_string[i] = '_';
+                }
+                formatted_hex_string[result.page_length - 1] = '.';
 
-                // int pos = 0;
-                // for(int i = 0; i < result.page_length - 1; i++) {
-                //     if(formatted_hex_string[i] != '_') {
-                //         formatted_hex_string[i] = hex_string[pos++];
-                //     }
-                // }
-                // formatted_hex_string[result.page_length - 1] = '_';
+                int pos = 0;
+                for(int i = 0; i < result.page_length - 1; i++) {
+                    if(formatted_hex_string[i] != '_') {
+                        formatted_hex_string[i] = hex_string[pos++];
+                    }
+                }
 
-                // memcpy(result.product_serial_number, formatted_hex_string, result.page_length);
-
-                // sprintf(hex_string, "%llx", identify_namespace_data.nguid[1]);
-                // pos = 0;
-                // for(int i = 0; i < result.page_length - 1; i++) {
-                //     if(formatted_hex_string[i] != '_') {
-                //         formatted_hex_string[i] = hex_string[pos++];
-                //     }
-                // }
-                // formatted_hex_string[result.page_length - 1] = '.';
-                // memcpy(&result.product_serial_number[20], formatted_hex_string, result.page_length);
+                memcpy(result.product_serial_number, formatted_hex_string, result.page_length);
 
             }
             else {
@@ -197,24 +188,31 @@ namespace inquiry {
             if(nguid_nz) {
                 // 6.1.3.1.1
                 result.page_length = 40;
+                char hex_string[33];
+                sprintf(hex_string, "%llx", identify_namespace_data.nguid[0]);
+                sprintf(&hex_string[16], "%llx", identify_namespace_data.nguid[1]);
 
+                char formatted_hex_string[41];
+                for(int i = 4; i < result.page_length; i+=5) {
+                    formatted_hex_string[i] = '_';
+                }
+                formatted_hex_string[result.page_length - 1] = '.';
+
+                int pos = 0;
+                for(int i = 0; i < result.page_length - 1; i++) {
+                    if(formatted_hex_string[i] != '_') {
+                        formatted_hex_string[i] = hex_string[pos++];
+                    }
+                }
+
+                memcpy(result.product_serial_number, formatted_hex_string, result.page_length);
             }
             else {
                 // 6.1.3.1.3
                 // valid for NVMe 1.0 devices only
-                
+                // TODO?
             }
         }
-
-        /*
-        Shall be set to a 20 byte value by translating the IEEE Extended Unique Identifier.
-
-        The EUI64 field shall be translated by converting each nibble into an ASCII
-        equivalent representation, right aligning, and inserting a “_”
-        after the 4th, 8th, 12th position, and a “.” after the 16th position
-        in the string. For example, “0x0123456789ABCDEF” would be
-        converted to “0123_4567_89AB_CDEF.”
-        */
         
         return result;
     }

--- a/lib/translate/inquiry.cc
+++ b/lib/translate/inquiry.cc
@@ -16,8 +16,8 @@
 
 namespace inquiry {
     // Creates and validates a Inquiry Command struct
-    std::optional<scsi_defs::InquiryCommand> raw_cmd_to_scsi_command(uint32_t* raw_cmd, int buffer_length) {
-        if (buffer_length == 0 || raw_cmd == nullptr) {
+    std::optional<scsi_defs::InquiryCommand> raw_cmd_to_scsi_command(absl::Span<const uint32_t> raw_cmd) {
+        if (raw_cmd.length() == 0 || raw_cmd.data() == nullptr) {
             printf("buffer is empty or nullptr\n");
             return std::nullopt;
         }
@@ -162,8 +162,8 @@ namespace inquiry {
 
     // TODO: write return value to a buffer
     // Main logic engine for the Inquiry command
-    void translate(uint32_t* raw_cmd, int buffer_length) {
-        std::optional<scsi_defs::InquiryCommand> opt_cmd = raw_cmd_to_scsi_command(raw_cmd, buffer_length);
+    void translate(absl::Span<const uint32_t> raw_cmd) {
+        std::optional<scsi_defs::InquiryCommand> opt_cmd = raw_cmd_to_scsi_command(raw_cmd);
         if (!opt_cmd.has_value()) return;
 
         scsi_defs::InquiryCommand cmd = opt_cmd.value();

--- a/lib/translate/inquiry.cc
+++ b/lib/translate/inquiry.cc
@@ -1,0 +1,93 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "inquiry.h"
+
+namespace inquiry {
+
+    scsi_defs::InquiryData* translate(uint32_t* raw_cmd, int buffer_length) {
+        if (buffer_length == 0 || raw_cmd == nullptr) {
+            printf("buffer is empty or nullptr\n");
+            return nullptr;
+        }
+
+        uint8_t opcode = raw_cmd[0];
+        if (static_cast<scsi_defs::OpCode>(opcode) != scsi_defs::OpCode::kInquiry) {
+            printf("invalid opcode. expected %ux. got %ux.", static_cast<uint8_t>(scsi_defs::OpCode::kInquiry), opcode);
+            return nullptr;
+        }
+
+        scsi_defs::InquiryCommand* scsi_cmd = reinterpret_cast<scsi_defs::InquiryCommand*>(raw_cmd[0]);
+ 
+        // TODO: check invalid parameters
+        if (scsi_cmd->evpd) {
+
+        }
+        else {
+            // Shall be supported by returning Standard INQUIRY Data to application client
+            
+            /*
+            TODO: actually execute nvme commands
+            The Identify command uses the Data Pointer, Command Dword 10, Command Dword 11, and Command
+            Dword 14 fields. All other command specific fields are reserved.
+            */
+
+            // Identify controller results
+            nvme_defs::IdentifyControllerData *identify_controller_data = new nvme_defs::IdentifyControllerData();
+            // Identify namespace results
+            nvme_defs::IdentifyNamespace *identify_namespace_data = new nvme_defs::IdentifyNamespace();
+
+            // SCSI Inquiry Standard Result
+            scsi_defs::InquiryData *scsi_result = new scsi_defs::InquiryData();
+            scsi_result->peripheral_qualifier = static_cast<scsi_defs::PeripheralQualifier>(0);
+            scsi_result->peripheral_device_type = static_cast<scsi_defs::PeripheralDeviceType>(0);
+            scsi_result->rmb = 0;
+            scsi_result->version = static_cast<scsi_defs::Version>(0x6);
+            scsi_result->normaca = 0;
+            scsi_result->hisup = 0;
+            scsi_result->response_data_format = static_cast<scsi_defs::ResponseDataFormat>(0b10);
+            scsi_result->additional_length = 0x1f;
+            scsi_result->sccs = 0;
+            scsi_result->acc = 0;
+            scsi_result->tpgs = static_cast<scsi_defs::TPGS>(0);
+            scsi_result->third_party_copy = 0;
+            scsi_result->protect = (identify_namespace_data->dps.pit == 0 and identify_namespace_data->dps.md_start == 0) ? 0 : 1;
+            scsi_result->encserv = 0;
+            scsi_result->multip = 0;
+            scsi_result->addr_16 = 0;
+            scsi_result->wbus_16 = 0;
+            scsi_result->sync = 0;
+            scsi_result->cmdque = 1;
+
+            // Shall be set to “NVMe” followed by 4 spaces: “NVMe “
+            char x[9] = "NVMe    ";
+            scsi_result->vendor_identification = *(reinterpret_cast<uint64_t*>(&x));
+            printf("%lux\n", scsi_result->vendor_identification);
+
+            // Shall be set to the first 16 bytes of the Model Number (MN) field within the Identify Controller Data Structure
+            for(int i = 0; i < 16; i++) {
+                scsi_result->product_identification[i] = identify_controller_data->mn[i];
+            }
+
+            // Shall be set to the first 4 bytes of the Firmware Revision (FR) field within the Identify Controller Data Structure
+            for(int i = 0; i < 4; i++) {
+                scsi_result->product_revision_level <<= 8;
+                scsi_result->product_revision_level |= identify_controller_data->fr[i];
+            }
+            return scsi_result;
+        }
+
+        return nullptr;
+    }
+};

--- a/lib/translate/inquiry.cc
+++ b/lib/translate/inquiry.cc
@@ -85,7 +85,7 @@ namespace inquiry {
         for(int i = 7; i >= 0; i--) {
             if(identify_controller_data.fr[i] != ' ' && identify_controller_data.fr[i] >= 0x21 && identify_controller_data.fr[i] <= 0x7e) {
                 result.product_revision_level[idx] = identify_controller_data.fr[i];
-                printf("IDX %d\n", idx);
+                // printf("IDX %d\n", idx);
                 idx--;
                 if(idx == -1) break;
             }

--- a/lib/translate/inquiry.cc
+++ b/lib/translate/inquiry.cc
@@ -78,10 +78,19 @@ namespace inquiry {
             result.product_identification[i] = identify_controller_data.mn[i];
         }
 
-        // Shall be set to the first 4 bytes of the Firmware Revision (FR) field within the Identify Controller Data Structure
-        for(int i = 0; i < 4; i++) {
-            result.product_revision_level[i] = identify_controller_data.fr[i];
+        /* Shall be set to the last 4 ASCII graphic characters in the range of 21h-7Eh (i.e. last 4 non-space
+        characters) of the Firmware Revision (FR) field within the Identify Controller Data Structure.
+        */
+        int idx = 3;
+        for(int i = 7; i >= 0; i--) {
+            if(identify_controller_data.fr[i] != ' ' && identify_controller_data.fr[i] >= 0x21 && identify_controller_data.fr[i] <= 0x7e) {
+                result.product_revision_level[idx] = identify_controller_data.fr[i];
+                printf("IDX %d\n", idx);
+                idx--;
+                if(idx == -1) break;
+            }
         }
+        if(idx >= 0) printf("less than four characters set\n");
         return result;
     }
     scsi_defs::InquiryData build_standard_inquiry() {
@@ -119,7 +128,36 @@ namespace inquiry {
         result.peripheral_qualifier = scsi_defs::PeripheralQualifier::kPeripheralDeviceConnected;
         result.peripheral_device_type = scsi_defs::PeripheralDeviceType::kDirectAccessBlock;
         result.page_code = 0x80;
-        result.page_length = 20;
+
+        // for(int i = 0;)
+        // identify_namespace_data
+        
+        // if(eui64) {
+        //     if(nguid) {
+        //         // 6.1.3.1.1
+        //         // nguid
+        //         result.page_length = 40;
+
+        //     }
+        //     else {
+        //         // 6.1.3.1.2
+        //         // eui64
+        //         result.page_length = 20;
+
+        //     }
+        // }
+        // else {
+        //     if(nguid) {
+        //         // 6.1.3.1.1
+        //         result.page_length = 40;
+
+        //     }
+        //     else {
+        //         // 6.1.3.1.3
+        //         // valid for NVMe 1.0 devices only
+                
+        //     }
+        // }
 
         /*
         Shall be set to a 20 byte value by translating the IEEE Extended Unique Identifier.
@@ -131,6 +169,7 @@ namespace inquiry {
         converted to “0123_4567_89AB_CDEF.”
         */
         
+        printf("%l\n", identify_namespace_data.eui64);
         char hex_string[17];
         sprintf(hex_string, "%X", identify_namespace_data.eui64);
         char formatted_hex_string[21];

--- a/lib/translate/inquiry.cc
+++ b/lib/translate/inquiry.cc
@@ -15,255 +15,284 @@
 #include "inquiry.h"
 #include "string.h"
 namespace inquiry {
-    // Creates and validates a Inquiry Command struct
-    std::optional<scsi_defs::InquiryCommand> raw_cmd_to_scsi_command(absl::Span<const uint32_t> raw_cmd) {
-        if (raw_cmd.empty()) {
-            printf("buffer is empty or nullptr\n");
-            return std::nullopt;
+// Creates and validates a Inquiry Command struct
+std::optional<scsi_defs::InquiryCommand> raw_cmd_to_scsi_command(
+    absl::Span<const uint32_t> raw_cmd) {
+  if (raw_cmd.empty()) {
+    printf("buffer is empty or nullptr\n");
+    return std::nullopt;
+  }
+
+  uint8_t opcode = raw_cmd[0];
+  if (static_cast<scsi_defs::OpCode>(opcode) != scsi_defs::OpCode::kInquiry) {
+    printf("invalid opcode. expected %ux. got %ux.",
+           static_cast<uint8_t>(scsi_defs::OpCode::kInquiry), opcode);
+    return std::nullopt;
+  }
+
+  // printf("opcode is good, casting\n");
+  // TODO: check invalid parameters in scsi_command
+  return std::make_optional(
+      *reinterpret_cast<const scsi_defs::InquiryCommand*>(&raw_cmd[1]));
+}
+
+// Executes the NVME Identify Controller command
+nvme_defs::IdentifyControllerData nvme_identify_controller() {
+  // TODO
+  return nvme_defs::IdentifyControllerData();
+}
+
+// Executes the NVME Identify Namespace command
+nvme_defs::IdentifyNamespace nvme_identify_namespace() {
+  // TODO
+  return nvme_defs::IdentifyNamespace();
+}
+
+scsi_defs::InquiryData translate_standard_inquiry_response(
+    nvme_defs::IdentifyControllerData identify_controller_data,
+    nvme_defs::IdentifyNamespace identify_namespace_data) {
+  // SCSI Inquiry Standard Result
+  // https://www.nvmexpress.org/wp-content/uploads/NVM-Express-SCSI-Translation-Reference-1_1-Gold.pdf
+  // Section 6.1.1
+  scsi_defs::InquiryData result = scsi_defs::InquiryData();
+  result.peripheral_qualifier = static_cast<scsi_defs::PeripheralQualifier>(0);
+  result.peripheral_device_type =
+      static_cast<scsi_defs::PeripheralDeviceType>(0);
+  result.rmb = 0;
+  result.version = static_cast<scsi_defs::Version>(0x6);
+  result.normaca = 0;
+  result.hisup = 0;
+  result.response_data_format =
+      static_cast<scsi_defs::ResponseDataFormat>(0b10);
+  result.additional_length = 0x1f;
+  result.sccs = 0;
+  result.acc = 0;
+  result.tpgs = static_cast<scsi_defs::TPGS>(0);
+  result.third_party_copy = 0;
+  result.protect = (identify_namespace_data.dps.pit == 0 &&
+                    identify_namespace_data.dps.md_start == 0)
+                       ? 0
+                       : 1;
+  result.encserv = 0;
+  result.multip = 0;
+  result.addr_16 = 0;
+  result.wbus_16 = 0;
+  result.sync = 0;
+  result.cmdque = 1;
+
+  // Shall be set to “NVMe” followed by 4 spaces: “NVMe “
+  char NVME_VENDOR_IDENTIFICATION[9] = "NVMe    ";
+  strncpy(result.vendor_identification, NVME_VENDOR_IDENTIFICATION, 8);
+
+  // Shall be set to the first 16 bytes of the Model Number (MN) field within
+  // the Identify Controller Data Structure
+  memcpy(result.product_identification, identify_controller_data.mn, 16);
+
+  /*
+  Shall be set to the last 4 ASCII graphic characters in the range of 21h-7Eh
+  (i.e. last 4 non-space characters) of the Firmware Revision (FR) field within
+  the Identify Controller Data Structure.
+  */
+  int idx = 3;
+  for (int i = 7; i >= 0; i--) {
+    if (identify_controller_data.fr[i] != ' ' &&
+        identify_controller_data.fr[i] >= 0x21 &&
+        identify_controller_data.fr[i] <= 0x7e) {
+      result.product_revision_level[idx] = identify_controller_data.fr[i];
+      if (idx-- == 0) break;
+    }
+  }
+  if (idx >= 0) printf("less than four characters set\n");
+  return result;
+}
+scsi_defs::InquiryData build_standard_inquiry() {
+  // Identify controller results
+  nvme_defs::IdentifyControllerData identify_controller_data =
+      nvme_identify_controller();
+  // Identify namespace results
+  nvme_defs::IdentifyNamespace identify_namespace_data =
+      nvme_identify_namespace();
+  return translate_standard_inquiry_response(identify_controller_data,
+                                             identify_namespace_data);
+}
+
+scsi_defs::SupportedVitalProductData build_supported_vpd_pages() {
+  scsi_defs::SupportedVitalProductData result =
+      scsi_defs::SupportedVitalProductData();
+  result.peripheral_qualifier =
+      scsi_defs::PeripheralQualifier::kPeripheralDeviceConnected;
+  result.peripheral_device_type =
+      scsi_defs::PeripheralDeviceType::kDirectAccessBlock;
+  result.page_code = 0;
+
+  // Shall be set to 5 indicating number of items supported VPD pages list
+  // requires. NOTE: document says to set this to 5 but there are 7 entries....
+  result.page_length = 5;
+
+  result.supported_page_list[0] = 0x00;
+  result.supported_page_list[1] = 0x80;
+  result.supported_page_list[2] = 0x83;
+  result.supported_page_list[3] = 0x86;
+  result.supported_page_list[4] = 0xB0;
+  result.supported_page_list[5] = 0xB1;
+  result.supported_page_list[6] = 0xB2;
+  return result;
+}
+
+scsi_defs::UnitSerialNumber translate_unit_serial_number_vpd_response(
+    nvme_defs::IdentifyNamespace identify_namespace_data) {
+  scsi_defs::UnitSerialNumber result = scsi_defs::UnitSerialNumber();
+  result.peripheral_qualifier =
+      scsi_defs::PeripheralQualifier::kPeripheralDeviceConnected;
+  result.peripheral_device_type =
+      scsi_defs::PeripheralDeviceType::kDirectAccessBlock;
+  result.page_code = 0x80;
+
+  // check if nonzero
+  bool nguid_nz =
+      identify_namespace_data.nguid[0] || identify_namespace_data.nguid[1];
+  bool eui64_nz = identify_namespace_data.eui64;
+  if (eui64_nz) {
+    if (nguid_nz) {
+      // 6.1.3.1.1
+      result.page_length = 40;
+
+      // convert 128-bit number into hex string
+      char hex_string[33];
+      sprintf(hex_string, "%llx", identify_namespace_data.nguid[0]);
+      sprintf(&hex_string[16], "%llx", identify_namespace_data.nguid[1]);
+
+      // insert _ and . in the correct positions
+      char formatted_hex_string[41];
+      for (int i = 4; i < result.page_length; i += 5) {
+        formatted_hex_string[i] = '_';
+      }
+      formatted_hex_string[result.page_length - 1] = '.';
+
+      // insert numbers
+      int pos = 0;
+      for (int i = 0; i < result.page_length - 1; i++) {
+        if (formatted_hex_string[i] != '_') {
+          formatted_hex_string[i] = hex_string[pos++];
         }
+      }
 
-        uint8_t opcode = raw_cmd[0];
-        if (static_cast<scsi_defs::OpCode>(opcode) != scsi_defs::OpCode::kInquiry) {
-            printf("invalid opcode. expected %ux. got %ux.", static_cast<uint8_t>(scsi_defs::OpCode::kInquiry), opcode);
-            return std::nullopt;
+      memcpy(result.product_serial_number, formatted_hex_string,
+             result.page_length);
+    } else {
+      // 6.1.3.1.2
+      result.page_length = 20;
+
+      // convert 128-bit number into hex string
+      char hex_string[17];
+      sprintf(hex_string, "%llx", identify_namespace_data.eui64);
+
+      // insert _ and . in the correct positions
+      char formatted_hex_string[21];
+      for (int i = 4; i < result.page_length; i += 5) {
+        formatted_hex_string[i] = '_';
+      }
+      formatted_hex_string[result.page_length - 1] = '.';
+
+      // insert numbers
+      int pos = 0;
+      for (int i = 0; i < result.page_length - 1; i++) {
+        if (formatted_hex_string[i] != '_') {
+          formatted_hex_string[i] = hex_string[pos++];
         }
+      }
 
-        // printf("opcode is good, casting\n");
-        // TODO: check invalid parameters in scsi_command
-        return std::make_optional(*reinterpret_cast<const scsi_defs::InquiryCommand*>(&raw_cmd[1]));
+      memcpy(result.product_serial_number, formatted_hex_string,
+             result.page_length);
     }
+  } else {
+    if (nguid_nz) {
+      // 6.1.3.1.1
+      result.page_length = 40;
 
-    // Executes the NVME Identify Controller command
-    nvme_defs::IdentifyControllerData nvme_identify_controller() {
-        // TODO
-        return nvme_defs::IdentifyControllerData();
-    }
+      // convert 128-bit number into hex string
+      char hex_string[33];
+      sprintf(hex_string, "%llx", identify_namespace_data.nguid[0]);
+      sprintf(&hex_string[16], "%llx", identify_namespace_data.nguid[1]);
 
-    // Executes the NVME Identify Namespace command
-    nvme_defs::IdentifyNamespace nvme_identify_namespace() {
-        // TODO
-        return nvme_defs::IdentifyNamespace();
-    }
+      // insert _ and . in the correct positions
+      char formatted_hex_string[41];
+      for (int i = 4; i < result.page_length; i += 5) {
+        formatted_hex_string[i] = '_';
+      }
+      formatted_hex_string[result.page_length - 1] = '.';
 
-    scsi_defs::InquiryData translate_standard_inquiry_response(nvme_defs::IdentifyControllerData identify_controller_data, nvme_defs::IdentifyNamespace identify_namespace_data) {
-        // SCSI Inquiry Standard Result
-        // https://www.nvmexpress.org/wp-content/uploads/NVM-Express-SCSI-Translation-Reference-1_1-Gold.pdf
-        // Section 6.1.1
-        scsi_defs::InquiryData result = scsi_defs::InquiryData();
-        result.peripheral_qualifier = static_cast<scsi_defs::PeripheralQualifier>(0);
-        result.peripheral_device_type = static_cast<scsi_defs::PeripheralDeviceType>(0);
-        result.rmb = 0;
-        result.version = static_cast<scsi_defs::Version>(0x6);
-        result.normaca = 0;
-        result.hisup = 0;
-        result.response_data_format = static_cast<scsi_defs::ResponseDataFormat>(0b10);
-        result.additional_length = 0x1f;
-        result.sccs = 0;
-        result.acc = 0;
-        result.tpgs = static_cast<scsi_defs::TPGS>(0);
-        result.third_party_copy = 0;
-        result.protect = (identify_namespace_data.dps.pit == 0 && identify_namespace_data.dps.md_start == 0) ? 0 : 1;
-        result.encserv = 0;
-        result.multip = 0;
-        result.addr_16 = 0;
-        result.wbus_16 = 0;
-        result.sync = 0;
-        result.cmdque = 1;
-
-        // Shall be set to “NVMe” followed by 4 spaces: “NVMe “
-        char NVME_VENDOR_IDENTIFICATION[9] = "NVMe    ";
-        strncpy(result.vendor_identification, NVME_VENDOR_IDENTIFICATION, 8);
-
-        // Shall be set to the first 16 bytes of the Model Number (MN) field within the Identify Controller Data Structure
-        memcpy(result.product_identification, identify_controller_data.mn, 16);
-
-        /* 
-        Shall be set to the last 4 ASCII graphic characters in the range of 21h-7Eh (i.e. last 4 non-space
-        characters) of the Firmware Revision (FR) field within the Identify Controller Data Structure.
-        */
-        int idx = 3;
-        for(int i = 7; i >= 0; i--) {
-            if(identify_controller_data.fr[i] != ' ' && identify_controller_data.fr[i] >= 0x21 && identify_controller_data.fr[i] <= 0x7e) {
-                result.product_revision_level[idx] = identify_controller_data.fr[i];
-                if(idx-- == 0) break;
-            }
+      // insert numbers
+      int pos = 0;
+      for (int i = 0; i < result.page_length - 1; i++) {
+        if (formatted_hex_string[i] != '_') {
+          formatted_hex_string[i] = hex_string[pos++];
         }
-        if(idx >= 0) printf("less than four characters set\n");
-        return result;
+      }
+
+      memcpy(result.product_serial_number, formatted_hex_string,
+             result.page_length);
+    } else {
+      // 6.1.3.1.3
+      // valid for NVMe 1.0 devices only
+      // TODO?
     }
-    scsi_defs::InquiryData build_standard_inquiry() {
-        // Identify controller results
-        nvme_defs::IdentifyControllerData identify_controller_data = nvme_identify_controller();
-        // Identify namespace results
-        nvme_defs::IdentifyNamespace identify_namespace_data = nvme_identify_namespace();
-        return translate_standard_inquiry_response(identify_controller_data, identify_namespace_data);
+  }
+
+  return result;
+}
+
+scsi_defs::UnitSerialNumber build_unit_serial_number_vpd() {
+  nvme_defs::IdentifyNamespace identify_namespace_data =
+      nvme_identify_namespace();
+  return translate_unit_serial_number_vpd_response(identify_namespace_data);
+}
+
+// TODO: write return value to a buffer
+// Main logic engine for the Inquiry command
+void translate(absl::Span<const uint32_t> raw_cmd) {
+  std::optional<scsi_defs::InquiryCommand> opt_cmd =
+      raw_cmd_to_scsi_command(raw_cmd);
+  if (!opt_cmd.has_value()) return;
+
+  scsi_defs::InquiryCommand cmd = opt_cmd.value();
+  if (cmd.evpd) {
+    switch (cmd.page_code) {
+      // Shall be supported by returning Supported VPD Pages data page to
+      // application client, refer to 6.1.2.
+      case 0x00: {
+        scsi_defs::SupportedVitalProductData result =
+            build_supported_vpd_pages();
+        break;
+      }
+      // Shall be supported by returning Unit Serial Number data page to
+      // application client. Refer to 6.1.3.
+      case 0x80: {
+        scsi_defs::UnitSerialNumber result = build_unit_serial_number_vpd();
+        break;
+      }
+      // Shall be supported by returning Device Identification data page to
+      // application client, refer to 6.1.4
+      case 0x83:
+        break;
+      // May optionally be supported by returning Extended INQUIRY data page to
+      // application client, refer to 6.1.5.
+      case 0x86:
+        break;
+      // Shall be supported by returning Block Device Characteristics VPD Page
+      // to application client, refer to 6.1.7.
+      case 0xB1:
+        break;
+      // Command may be terminated with CHECK CONDITION status, ILLEGAL REQUEST
+      // sense key, and ILLEGAL FIELD IN CDB additional sense code
+      default:
+        break;
     }
-
-    scsi_defs::SupportedVitalProductData build_supported_vpd_pages()
-    {
-        scsi_defs::SupportedVitalProductData result = scsi_defs::SupportedVitalProductData();
-        result.peripheral_qualifier = scsi_defs::PeripheralQualifier::kPeripheralDeviceConnected;
-        result.peripheral_device_type = scsi_defs::PeripheralDeviceType::kDirectAccessBlock;
-        result.page_code = 0;
-
-        // Shall be set to 5 indicating number of items supported VPD pages list requires.
-        // NOTE: document says to set this to 5 but there are 7 entries....
-        result.page_length = 5;
-
-        result.supported_page_list[0] = 0x00;
-        result.supported_page_list[1] = 0x80;
-        result.supported_page_list[2] = 0x83;
-        result.supported_page_list[3] = 0x86;
-        result.supported_page_list[4] = 0xB0;
-        result.supported_page_list[5] = 0xB1;
-        result.supported_page_list[6] = 0xB2;
-        return result;
-    }
-
-
-    scsi_defs::UnitSerialNumber translate_unit_serial_number_vpd_response(nvme_defs::IdentifyNamespace identify_namespace_data) {
-        scsi_defs::UnitSerialNumber result = scsi_defs::UnitSerialNumber();
-        result.peripheral_qualifier = scsi_defs::PeripheralQualifier::kPeripheralDeviceConnected;
-        result.peripheral_device_type = scsi_defs::PeripheralDeviceType::kDirectAccessBlock;
-        result.page_code = 0x80;
-        
-        // check if nonzero
-        bool nguid_nz = identify_namespace_data.nguid[0] || identify_namespace_data.nguid[1];
-        bool eui64_nz = identify_namespace_data.eui64;
-        if(eui64_nz) {
-            if(nguid_nz) {
-                // 6.1.3.1.1
-                result.page_length = 40;
-
-                // convert 128-bit number into hex string
-                char hex_string[33];
-                sprintf(hex_string, "%llx", identify_namespace_data.nguid[0]);
-                sprintf(&hex_string[16], "%llx", identify_namespace_data.nguid[1]);
-
-                // insert _ and . in the correct positions
-                char formatted_hex_string[41];
-                for(int i = 4; i < result.page_length; i+=5) {
-                    formatted_hex_string[i] = '_';
-                }
-                formatted_hex_string[result.page_length - 1] = '.';
-
-                // insert numbers
-                int pos = 0;
-                for(int i = 0; i < result.page_length - 1; i++) {
-                    if(formatted_hex_string[i] != '_') {
-                        formatted_hex_string[i] = hex_string[pos++];
-                    }
-                }
-
-                memcpy(result.product_serial_number, formatted_hex_string, result.page_length);
-            }
-            else {
-                // 6.1.3.1.2
-                result.page_length = 20;
-
-                // convert 128-bit number into hex string
-                char hex_string[17];
-                sprintf(hex_string, "%llx", identify_namespace_data.eui64);
-
-                // insert _ and . in the correct positions
-                char formatted_hex_string[21];
-                for(int i = 4; i < result.page_length; i+=5) {
-                    formatted_hex_string[i] = '_';
-                }
-                formatted_hex_string[result.page_length - 1] = '.';
-
-                // insert numbers
-                int pos = 0;
-                for(int i = 0; i < result.page_length - 1; i++) {
-                    if(formatted_hex_string[i] != '_') {
-                        formatted_hex_string[i] = hex_string[pos++];
-                    }
-                }
-
-                memcpy(result.product_serial_number, formatted_hex_string, result.page_length);
-            }
-        }
-        else {
-            if(nguid_nz) {
-                // 6.1.3.1.1
-                result.page_length = 40;
-
-                // convert 128-bit number into hex string
-                char hex_string[33];
-                sprintf(hex_string, "%llx", identify_namespace_data.nguid[0]);
-                sprintf(&hex_string[16], "%llx", identify_namespace_data.nguid[1]);
-
-                // insert _ and . in the correct positions
-                char formatted_hex_string[41];
-                for(int i = 4; i < result.page_length; i+=5) {
-                    formatted_hex_string[i] = '_';
-                }
-                formatted_hex_string[result.page_length - 1] = '.';
-
-                // insert numbers
-                int pos = 0;
-                for(int i = 0; i < result.page_length - 1; i++) {
-                    if(formatted_hex_string[i] != '_') {
-                        formatted_hex_string[i] = hex_string[pos++];
-                    }
-                }
-
-                memcpy(result.product_serial_number, formatted_hex_string, result.page_length);
-            }
-            else {
-                // 6.1.3.1.3
-                // valid for NVMe 1.0 devices only
-                // TODO?
-            }
-        }
-        
-        return result;
-    }
-
-    scsi_defs::UnitSerialNumber build_unit_serial_number_vpd() {
-        nvme_defs::IdentifyNamespace identify_namespace_data = nvme_identify_namespace();
-        return translate_unit_serial_number_vpd_response(identify_namespace_data);
-    }
-
-    // TODO: write return value to a buffer
-    // Main logic engine for the Inquiry command
-    void translate(absl::Span<const uint32_t> raw_cmd) {
-        std::optional<scsi_defs::InquiryCommand> opt_cmd = raw_cmd_to_scsi_command(raw_cmd);
-        if (!opt_cmd.has_value()) return;
-
-        scsi_defs::InquiryCommand cmd = opt_cmd.value();
-        if (cmd.evpd) {
-            switch (cmd.page_code) {
-                // Shall be supported by returning Supported VPD Pages data page to application client, refer to 6.1.2.
-                case 0x00:
-                 {
-                    scsi_defs::SupportedVitalProductData result = build_supported_vpd_pages();
-                    break;
-                 }
-                // Shall be supported by returning Unit Serial Number data page to application client. Refer to 6.1.3.
-                case 0x80:
-                 {
-                    scsi_defs::UnitSerialNumber result = build_unit_serial_number_vpd();
-                    break;
-                 }
-                // Shall be supported by returning Device Identification data page to application client, refer to 6.1.4
-                case 0x83:
-                    break;
-                // May optionally be supported by returning Extended INQUIRY data page to application client, refer to 6.1.5.
-                case 0x86:
-                    break;
-                // Shall be supported by returning Block Device Characteristics VPD Page to application client, refer to 6.1.7.
-                case 0xB1:
-                    break;
-                // Command may be terminated with CHECK CONDITION status, ILLEGAL REQUEST sense key, and ILLEGAL FIELD IN CDB additional sense code
-                default:
-                    break;
-            }
-        }
-        else {
-            // Shall be supported by returning Standard INQUIRY Data to application client
-            scsi_defs::InquiryData result = build_standard_inquiry();
-        }
-        return;
-    }
-};
+  } else {
+    // Shall be supported by returning Standard INQUIRY Data to application
+    // client
+    scsi_defs::InquiryData result = build_standard_inquiry();
+  }
+  return;
+}
+};  // namespace inquiry

--- a/lib/translate/inquiry.cc
+++ b/lib/translate/inquiry.cc
@@ -134,16 +134,20 @@ namespace inquiry {
             if(nguid_nz) {
                 // 6.1.3.1.1
                 result.page_length = 40;
+
+                // convert 128-bit number into hex string
                 char hex_string[33];
                 sprintf(hex_string, "%llx", identify_namespace_data.nguid[0]);
                 sprintf(&hex_string[16], "%llx", identify_namespace_data.nguid[1]);
 
+                // insert _ and . in the correct positions
                 char formatted_hex_string[41];
                 for(int i = 4; i < result.page_length; i+=5) {
                     formatted_hex_string[i] = '_';
                 }
                 formatted_hex_string[result.page_length - 1] = '.';
 
+                // insert numbers
                 int pos = 0;
                 for(int i = 0; i < result.page_length - 1; i++) {
                     if(formatted_hex_string[i] != '_') {
@@ -152,21 +156,23 @@ namespace inquiry {
                 }
 
                 memcpy(result.product_serial_number, formatted_hex_string, result.page_length);
-
             }
             else {
                 // 6.1.3.1.2
                 result.page_length = 20;
 
+                // convert 128-bit number into hex string
                 char hex_string[17];
                 sprintf(hex_string, "%llx", identify_namespace_data.eui64);
 
+                // insert _ and . in the correct positions
                 char formatted_hex_string[21];
                 for(int i = 4; i < result.page_length; i+=5) {
                     formatted_hex_string[i] = '_';
                 }
                 formatted_hex_string[result.page_length - 1] = '.';
 
+                // insert numbers
                 int pos = 0;
                 for(int i = 0; i < result.page_length - 1; i++) {
                     if(formatted_hex_string[i] != '_') {
@@ -181,16 +187,20 @@ namespace inquiry {
             if(nguid_nz) {
                 // 6.1.3.1.1
                 result.page_length = 40;
+
+                // convert 128-bit number into hex string
                 char hex_string[33];
                 sprintf(hex_string, "%llx", identify_namespace_data.nguid[0]);
                 sprintf(&hex_string[16], "%llx", identify_namespace_data.nguid[1]);
 
+                // insert _ and . in the correct positions
                 char formatted_hex_string[41];
                 for(int i = 4; i < result.page_length; i+=5) {
                     formatted_hex_string[i] = '_';
                 }
                 formatted_hex_string[result.page_length - 1] = '.';
 
+                // insert numbers
                 int pos = 0;
                 for(int i = 0; i < result.page_length - 1; i++) {
                     if(formatted_hex_string[i] != '_') {

--- a/lib/translate/inquiry.cc
+++ b/lib/translate/inquiry.cc
@@ -122,8 +122,8 @@ namespace inquiry {
         result.page_length = 20;
 
         /*
-        Shall be set to a 20 byte value by translating the IEEE Extended
-        Unique Identifier.
+        Shall be set to a 20 byte value by translating the IEEE Extended Unique Identifier.
+
         The EUI64 field shall be translated by converting each nibble into an ASCII
         equivalent representation, right aligning, and inserting a “_”
         after the 4th, 8th, 12th position, and a “.” after the 16th position

--- a/lib/translate/inquiry.h
+++ b/lib/translate/inquiry.h
@@ -1,0 +1,33 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef LIB_INQUIRY_H
+#define LIB_INQUIEY_H
+
+#include "../../third_party/spdk_defs/nvme_defs.h"
+#include "../scsi_defs.h"
+#include <cstdio>
+
+namespace inquiry {
+
+// scsi_defs::InquiryCommand* raw_to_scsi_command(uint32_t* raw_command, int length);
+// uint32_t* scsi_to_nvme_command(scsi_defs::InquiryCommand*);
+// uint32_t exec_nvme(uint32_t* nvme_command);
+// uint32_t* nvme_to_scsi_result_SPECIFIER(uint32_t*, uint32_t*);
+
+
+
+};
+
+#endif

--- a/lib/translate/inquiry.h
+++ b/lib/translate/inquiry.h
@@ -21,13 +21,6 @@
 
 namespace inquiry {
 
-// scsi_defs::InquiryCommand* raw_to_scsi_command(uint32_t* raw_command, int length);
-// uint32_t* scsi_to_nvme_command(scsi_defs::InquiryCommand*);
-// uint32_t exec_nvme(uint32_t* nvme_command);
-// uint32_t* nvme_to_scsi_result_SPECIFIER(uint32_t*, uint32_t*);
-
-
-
 };
 
 #endif

--- a/lib/translate/inquiry.h
+++ b/lib/translate/inquiry.h
@@ -17,12 +17,13 @@
 
 #include "../../third_party/spdk_defs/nvme_defs.h"
 #include "../scsi_defs.h"
+#include "absl/types/span.h"
 #include <cstdio>
 #include <optional>
 
 namespace inquiry {
-    void translate(uint32_t* raw_cmd, int buffer_length);
-    std::optional<scsi_defs::InquiryCommand> raw_cmd_to_scsi_command(uint32_t* raw_cmd, int buffer_length);
+    void translate(absl::Span<const uint32_t>);
+    std::optional<scsi_defs::InquiryCommand> raw_cmd_to_scsi_command(absl::Span<const uint32_t>);
 
     nvme_defs::IdentifyControllerData nvme_identify_controller();
     nvme_defs::IdentifyNamespace nvme_identify_namespace();

--- a/lib/translate/inquiry.h
+++ b/lib/translate/inquiry.h
@@ -18,6 +18,7 @@
 #include "../../third_party/spdk_defs/nvme_defs.h"
 #include "../scsi_defs.h"
 #include <cstdio>
+#include <optional>
 
 namespace inquiry {
 

--- a/lib/translate/inquiry.h
+++ b/lib/translate/inquiry.h
@@ -15,27 +15,31 @@
 #ifndef LIB_INQUIRY_H
 #define LIB_INQUIEY_H
 
+#include <cstdio>
+#include <optional>
 #include "../../third_party/spdk_defs/nvme_defs.h"
 #include "../scsi_defs.h"
 #include "absl/types/span.h"
-#include <cstdio>
-#include <optional>
 
 namespace inquiry {
-    void translate(absl::Span<const uint32_t>);
-    std::optional<scsi_defs::InquiryCommand> raw_cmd_to_scsi_command(absl::Span<const uint32_t>);
+void translate(absl::Span<const uint32_t>);
+std::optional<scsi_defs::InquiryCommand> raw_cmd_to_scsi_command(
+    absl::Span<const uint32_t>);
 
-    nvme_defs::IdentifyControllerData nvme_identify_controller();
-    nvme_defs::IdentifyNamespace nvme_identify_namespace();
+nvme_defs::IdentifyControllerData nvme_identify_controller();
+nvme_defs::IdentifyNamespace nvme_identify_namespace();
 
-    scsi_defs::InquiryData build_standard_inquiry();
-    scsi_defs::InquiryData translate_standard_inquiry_response(nvme_defs::IdentifyControllerData identify_controller_data, nvme_defs::IdentifyNamespace identify_namespace_data);
+scsi_defs::InquiryData build_standard_inquiry();
+scsi_defs::InquiryData translate_standard_inquiry_response(
+    nvme_defs::IdentifyControllerData identify_controller_data,
+    nvme_defs::IdentifyNamespace identify_namespace_data);
 
-    scsi_defs::SupportedVitalProductData build_supported_vpd_pages();
+scsi_defs::SupportedVitalProductData build_supported_vpd_pages();
 
-    scsi_defs::UnitSerialNumber build_unit_serial_number_vpd();
-    scsi_defs::UnitSerialNumber translate_unit_serial_number_vpd_response(nvme_defs::IdentifyNamespace identify_namespace_data);
+scsi_defs::UnitSerialNumber build_unit_serial_number_vpd();
+scsi_defs::UnitSerialNumber translate_unit_serial_number_vpd_response(
+    nvme_defs::IdentifyNamespace identify_namespace_data);
 
-};
+};  // namespace inquiry
 
 #endif

--- a/lib/translate/inquiry.h
+++ b/lib/translate/inquiry.h
@@ -21,6 +21,19 @@
 #include <optional>
 
 namespace inquiry {
+    void translate(uint32_t* raw_cmd, int buffer_length);
+    std::optional<scsi_defs::InquiryCommand> raw_cmd_to_scsi_command(uint32_t* raw_cmd, int buffer_length);
+
+    nvme_defs::IdentifyControllerData nvme_identify_controller();
+    nvme_defs::IdentifyNamespace nvme_identify_namespace();
+
+    scsi_defs::InquiryData build_standard_inquiry();
+    scsi_defs::InquiryData translate_standard_inquiry_response(nvme_defs::IdentifyControllerData identify_controller_data, nvme_defs::IdentifyNamespace identify_namespace_data);
+
+    scsi_defs::SupportedVitalProductData build_supported_vpd_pages();
+
+    scsi_defs::UnitSerialNumber build_unit_serial_number_vpd();
+    scsi_defs::UnitSerialNumber translate_unit_serial_number_vpd_response(nvme_defs::IdentifyNamespace identify_namespace_data);
 
 };
 

--- a/test/BUILD
+++ b/test/BUILD
@@ -7,5 +7,6 @@ cc_test(
         "//third_party/spdk_defs:nvme_defs_lib",
         "@googletest//:gtest_main",
         "@com_google_absl//absl/base",
+        "//lib/translate:inquiry_lib"
     ],
 )

--- a/test/inquiry_test.cc
+++ b/test/inquiry_test.cc
@@ -1,0 +1,87 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "../lib/translate/inquiry.h"
+
+#include <stdlib.h>
+
+#include "gtest/gtest.h"
+
+// Tests
+
+namespace {
+
+TEST(translteInquiryRawToSCSI, empty) {
+    absl::Span<const uint32_t> raw_cmd;
+    std::optional<scsi_defs::InquiryCommand> result = inquiry::translteInquiryRawToSCSI(raw_cmd);
+    ASSERT_FALSE(result.has_value());
+}
+
+TEST(translteInquiryRawToSCSI, wrongOp) {
+    const uint32_t buf = 4;
+    absl::Span<const uint32_t> raw_cmd = absl::MakeSpan(&buf, 1);
+    std::optional<scsi_defs::InquiryCommand> result = inquiry::translteInquiryRawToSCSI(raw_cmd);
+    ASSERT_FALSE(result.has_value());
+}
+
+TEST(translteInquiryRawToSCSI, defaultHappyPath) {
+    uint32_t sz = 1+sizeof(scsi_defs::InquiryCommand);
+    uint32_t * buf = (uint32_t*)malloc(4 * sz);
+    buf[0] = static_cast<uint32_t>(scsi_defs::OpCode::kInquiry);
+
+    scsi_defs::InquiryCommand * cmd = (scsi_defs::InquiryCommand *) &buf[1];
+    *cmd = scsi_defs::InquiryCommand();
+    absl::Span<const uint32_t> raw_cmd = absl::MakeSpan(buf, sz);
+    ASSERT_FALSE(raw_cmd.empty());
+
+    std::optional<scsi_defs::InquiryCommand> result = inquiry::translteInquiryRawToSCSI(raw_cmd);
+    ASSERT_TRUE(result.has_value());
+
+    scsi_defs::InquiryCommand result_cmd = result.value();
+    ASSERT_EQ(result_cmd.reserved, 0);
+    ASSERT_EQ(result_cmd.obsolete, 0);
+    ASSERT_EQ(result_cmd.evpd, 0);
+    ASSERT_EQ(result_cmd.page_code, 0);
+    ASSERT_EQ(result_cmd.allocation_length, 0);
+}
+
+// TODO: test invalid parameters in scsi_command
+TEST(translteInquiryRawToSCSI, customHappyPath) {
+    uint32_t sz = 1+sizeof(scsi_defs::InquiryCommand);
+    uint32_t * buf = (uint32_t*)malloc(4 * sz);
+    buf[0] = static_cast<uint32_t>(scsi_defs::OpCode::kInquiry);
+
+    scsi_defs::InquiryCommand * cmd = (scsi_defs::InquiryCommand *) &buf[1];
+    *cmd = scsi_defs::InquiryCommand();
+    cmd->evpd = 1;
+    cmd->page_code = 4;
+    cmd->allocation_length = 29;
+
+    absl::Span<const uint32_t> raw_cmd = absl::MakeSpan(buf, sz);
+    ASSERT_FALSE(raw_cmd.empty());
+
+    std::optional<scsi_defs::InquiryCommand> result = inquiry::translteInquiryRawToSCSI(raw_cmd);
+    ASSERT_TRUE(result.has_value());
+
+    scsi_defs::InquiryCommand result_cmd = result.value();
+    ASSERT_EQ(result_cmd.reserved, 0);
+    ASSERT_EQ(result_cmd.obsolete, 0);
+    ASSERT_EQ(result_cmd.evpd, 1);
+    ASSERT_EQ(result_cmd.page_code, 4);
+    ASSERT_EQ(result_cmd.allocation_length, 29);
+}
+TEST(translateStandardInquiryResponse, happyPath) {
+
+}
+}

--- a/test/inquiry_test.cc
+++ b/test/inquiry_test.cc
@@ -35,7 +35,7 @@ TEST(translteInquiryRawToSCSI, wrongOp) {
     ASSERT_FALSE(result.has_value());
 }
 
-TEST(translteInquiryRawToSCSI, defaultHappyPath) {
+TEST(translteInquiryRawToSCSI, defaultSuccess) {
     uint32_t sz = 1+sizeof(scsi_defs::InquiryCommand);
     uint32_t * buf = (uint32_t*)malloc(4 * sz);
     buf[0] = static_cast<uint32_t>(scsi_defs::OpCode::kInquiry);
@@ -57,7 +57,7 @@ TEST(translteInquiryRawToSCSI, defaultHappyPath) {
 }
 
 // TODO: test invalid parameters in scsi_command
-TEST(translteInquiryRawToSCSI, customHappyPath) {
+TEST(translteInquiryRawToSCSI, customSuccess) {
     uint32_t sz = 1+sizeof(scsi_defs::InquiryCommand);
     uint32_t * buf = (uint32_t*)malloc(4 * sz);
     buf[0] = static_cast<uint32_t>(scsi_defs::OpCode::kInquiry);
@@ -81,7 +81,16 @@ TEST(translteInquiryRawToSCSI, customHappyPath) {
     ASSERT_EQ(result_cmd.page_code, 4);
     ASSERT_EQ(result_cmd.allocation_length, 29);
 }
-TEST(translateStandardInquiryResponse, happyPath) {
+TEST(translateStandardInquiryResponse, Success) {
+
+}
+TEST(translateStandardInquiryResponse, badControllerData) {
+
+}
+TEST(translateStandardInquiryResponse, badNamespaceData) {
+
+}
+TEST(translateStandardInquiryResponse, noData) {
 
 }
 }

--- a/test/inquiry_test.cc
+++ b/test/inquiry_test.cc
@@ -143,4 +143,19 @@ TEST(translateStandardInquiryResponse, noData) {
 
 }
 
+TEST(supportedVPDPages, Success) {
+    scsi_defs::SupportedVitalProductData result = inquiry::build_supported_vpd_pages();
+
+    ASSERT_EQ(result.peripheral_qualifier , scsi_defs::PeripheralQualifier::kPeripheralDeviceConnected);
+    ASSERT_EQ(result.peripheral_device_type , scsi_defs::PeripheralDeviceType::kDirectAccessBlock);
+    ASSERT_EQ(result.page_code , 0);
+    ASSERT_EQ(result.page_length , 5);
+    ASSERT_EQ(result.supported_page_list[0] , 0x00);
+    ASSERT_EQ(result.supported_page_list[1] , 0x80);
+    ASSERT_EQ(result.supported_page_list[2] , 0x83);
+    ASSERT_EQ(result.supported_page_list[3] , 0x86);
+    ASSERT_EQ(result.supported_page_list[4] , 0xB0);
+    ASSERT_EQ(result.supported_page_list[5] , 0xB1);
+    ASSERT_EQ(result.supported_page_list[6] , 0xB2);
+}
 }

--- a/test/inquiry_test.cc
+++ b/test/inquiry_test.cc
@@ -130,13 +130,17 @@ TEST(translateStandardInquiryResponse, Success) {
     }
 }
 
+// TODO?
 TEST(translateStandardInquiryResponse, badControllerData) {
 
 }
+// TODO?
 TEST(translateStandardInquiryResponse, badNamespaceData) {
 
 }
+// TODO?
 TEST(translateStandardInquiryResponse, noData) {
 
 }
+
 }

--- a/third_party/spdk_defs/nvme_defs.h
+++ b/third_party/spdk_defs/nvme_defs.h
@@ -719,7 +719,7 @@ struct IdentifyNamespace {
   uint16_t noiob : 16;     // namespace optimal I/O boundary in logical blocks
   uint64_t nvmcap[2];      // NVM capacity
   uint8_t reserved64[40];  // includes fields added in NVMe Revision 1.4
-  uint8_t nguid[16];       // namespace globally unique identifier
+  uint64_t nguid[2];       // namespace globally unique identifier
   uint64_t eui64 : 64;     // IEEE extended unique identifier
 
   struct {


### PR DESCRIPTION
This is a proposal + example of how to structure future translation code.
**tl;dr: each SCSI command has its own "main engine" `translate(raw, len)` logic**. 

Problem: Our previous approach tried to separate translation of all commands into distinct steps which was difficult due to huge variations in translation processes. Some processes had extra steps, parameters, etc. A simple yet major problem with a generic engine approach is the million types of structs we have--difficult to implement all of that control flow in a single generic engine.

Solution: "main engines" for each command to allow for command-level flexibility, and allows us to assume some pre/post conditions (e.g we can assume we are operating on a certain command). This approach still allows modularity, e.g all nvme execution functions can be part of a library apart from the command-specifc engine. This is really simply a way to shift control flow away from a central main engine for every command.

Command specific main logic would look like this (identical to previous generic engine)
1. get raw intercepted scsi command as input
2. verify and cast to a command specific struct (e.g `raw_cmd_to_scsi_command()`)
3. examine command specific parameters (e.g. `evpd` and `page_code` for inquiry) for control flow
4. call more specific functions (including nvme) to build/execute these results. e.g `build_standard_inquiry_data()` and `nvme_identify_namespace()`

Control flow from the interceptor will look like this. Allows us to have only one place where we identify the command.
```
intercept_module() {
    uint8_t *cmd = intercept();
    uint8_t opcode = cmd[0];
    switch (opcode) {
        case 0x12: inquiry::translate(cmd, len);
        case ...: write::translate(cmd, len);
        case ...: read::translate(cmd, len);
        ....
    }
}
```

Please let me know your thoughts on this approach.