### PR TITLE
Translate Log Sense - Supported Pages List

### DIFF
--- a/lib/scsi_defs.h
+++ b/lib/scsi_defs.h
@@ -898,6 +898,15 @@ struct LogSenseCommand {
 } ABSL_ATTRIBUTE_PACKED;
 static_assert(sizeof(LogSenseCommand) == 10);
 
+struct SupoprtedLogPages {
+  bool ds :1;
+  bool spf_1b :1;
+  PageCode page_code : 6;
+  uint8_t _subpage_code : 8;
+  uint16_t page_len : 16;
+} ABSL_ATTRIBUTE_PACKED;
+static_assert(sizeof(SupoprtedLogPages) == 4);
+
 }  // namespace scsi_defs
 
 #endif

--- a/lib/scsi_defs.h
+++ b/lib/scsi_defs.h
@@ -27,9 +27,9 @@ using LunAddress = uint64_t;
 
 enum class PageCode : uint8_t {
   kSupportedLogPages = 0x00,
-  Temperature = 0x0d,
-  SolidStateMedia = 0x11,
-  InformationalExceptions = 0x2f
+  kTemperature = 0x0d,
+  kSolidStateMedia = 0x11,
+  kInformationalExceptions = 0x2f
 };
 
 // SAM-4 Table 33

--- a/lib/scsi_defs.h
+++ b/lib/scsi_defs.h
@@ -898,14 +898,14 @@ struct LogSenseCommand {
 } ABSL_ATTRIBUTE_PACKED;
 static_assert(sizeof(LogSenseCommand) == 10);
 
-struct SupoprtedLogPages {
+struct SupportedLogPages {
   bool ds :1;
   bool spf_1b :1;
   PageCode page_code : 6;
   uint8_t _subpage_code : 8;
   uint16_t page_len : 16;
 } ABSL_ATTRIBUTE_PACKED;
-static_assert(sizeof(SupoprtedLogPages) == 4);
+static_assert(sizeof(SupportedLogPages) == 4);
 
 }  // namespace scsi_defs
 

--- a/lib/scsi_defs.h
+++ b/lib/scsi_defs.h
@@ -25,6 +25,13 @@ namespace scsi_defs {
 
 using LunAddress = uint64_t;
 
+enum class PageCode : uint8_t {
+  kSupportedLogPages = 0x00,
+  Temperature = 0x0d,
+  SolidStateMedia = 0x11,
+  InformationalExceptions = 0x2f
+};
+
 // SAM-4 Table 33
 enum class Status : uint8_t {
   kGood = 0x0,
@@ -873,6 +880,23 @@ struct UnmapBlockDescriptor {
   uint32_t reserved_1 : 32;
 } ABSL_ATTRIBUTE_PACKED;
 static_assert(sizeof(UnmapBlockDescriptor) == 16);
+
+// SCSI Reference Manual Table 69
+// https://www.seagate.com/files/staticfiles/support/docs/manual/Interface%20manuals/100293068j.pdf
+struct LogSenseCommand {
+  uint8_t op_code : 8 = 0x4d;
+  uint8_t _reserved : 6;
+  bool obsolete : 1;
+  bool sp : 1;
+  uint8_t pc : 2;
+  PageCode page_code : 6;
+  uint8_t _subpage_code : 8; // unspecified
+  uint8_t _reserved2 : 8;
+  uint16_t _param_ptr : 16; // unspecified
+  uint16_t alloc_len : 16;
+  ControlByte control_byte;
+} ABSL_ATTRIBUTE_PACKED;
+static_assert(sizeof(LogSenseCommand) == 10);
 
 }  // namespace scsi_defs
 

--- a/lib/scsi_defs.h
+++ b/lib/scsi_defs.h
@@ -890,17 +890,17 @@ struct LogSenseCommand {
   bool sp : 1;
   uint8_t pc : 2;
   PageCode page_code : 6;
-  uint8_t _subpage_code : 8; // unspecified
+  uint8_t _subpage_code : 8;  // unspecified
   uint8_t _reserved2 : 8;
-  uint16_t _param_ptr : 16; // unspecified
+  uint16_t _param_ptr : 16;  // unspecified
   uint16_t alloc_len : 16;
   ControlByte control_byte;
 } ABSL_ATTRIBUTE_PACKED;
 static_assert(sizeof(LogSenseCommand) == 10);
 
 struct SupportedLogPages {
-  bool ds :1;
-  bool spf_1b :1;
+  bool ds : 1;
+  bool spf_1b : 1;
   PageCode page_code : 6;
   uint8_t _subpage_code : 8;
   uint16_t page_len : 16;

--- a/lib/translator/BUILD
+++ b/lib/translator/BUILD
@@ -5,3 +5,17 @@ cc_library(
   deps = [ ],
   visibility = ["//visibility:public"],
 )
+
+cc_library(
+  name = "logsense_lib",
+  hdrs = ["logsense.h"],
+  srcs = ["logsense.cc"],
+  deps = [
+      "//lib/translator:common",
+      "//third_party/spdk_defs:nvme_defs_lib",
+      "//lib:scsi_defs_lib",
+      "@com_google_absl//absl/base",
+      "@com_google_absl//absl/types:span",
+  ],
+  visibility = ["//visibility:public"],
+)

--- a/lib/translator/BUILD
+++ b/lib/translator/BUILD
@@ -16,6 +16,7 @@ cc_library(
       "//lib:scsi_defs_lib",
       "@com_google_absl//absl/base",
       "@com_google_absl//absl/types:span",
+      "@com_google_absl//absl/strings",
   ],
   visibility = ["//visibility:public"],
 )

--- a/lib/translator/logsense.cc
+++ b/lib/translator/logsense.cc
@@ -17,44 +17,41 @@
 namespace translator {
 
 void TranslateSupportedLogPages(absl::Span<uint8_t> buffer) {
-    scsi_defs::SupportedLogPages result = {
-        .page_len = 0x4
-    };
-    scsi_defs::PageCode supported_pages_list[4] = {
-        scsi_defs::PageCode::kSupportedLogPages,
-        scsi_defs::PageCode::kTemperature,
-        scsi_defs::PageCode::kSolidStateMedia,
-        scsi_defs::PageCode::kInformationalExceptions
-    };
-    memcpy(buffer.data(), &result, sizeof(scsi_defs::SupportedLogPages));
-    memcpy(&buffer[sizeof(scsi_defs::SupportedLogPages)], supported_pages_list, sizeof(supported_pages_list));
+  scsi_defs::SupportedLogPages result = {.page_len = 0x4};
+  scsi_defs::PageCode supported_pages_list[4] = {
+      scsi_defs::PageCode::kSupportedLogPages,
+      scsi_defs::PageCode::kTemperature, scsi_defs::PageCode::kSolidStateMedia,
+      scsi_defs::PageCode::kInformationalExceptions};
+  memcpy(buffer.data(), &result, sizeof(scsi_defs::SupportedLogPages));
+  memcpy(&buffer[sizeof(scsi_defs::SupportedLogPages)], supported_pages_list,
+         sizeof(supported_pages_list));
 }
 
 // Main logic engine for the Inquiry command
-void translate(const scsi_defs::LogSenseCommand &cmd, absl::Span<uint8_t> buffer) {
+void translate(const scsi_defs::LogSenseCommand &cmd,
+               absl::Span<uint8_t> buffer) {
+  if (cmd.sp == 1 || cmd.pc == 1 || cmd.control_byte.naca == 1) {
+    /*
+    Command may be terminated with CHECK CONDITION
+    status, ILLEGAL REQUEST sense key, and ILLEGAL FIELD IN
+    CDB additional sense code.
+    */
+  }
 
-    if (cmd.sp == 1 || cmd.pc == 1 || cmd.control_byte.naca == 1) {
-        /*
-        Command may be terminated with CHECK CONDITION
-        status, ILLEGAL REQUEST sense key, and ILLEGAL FIELD IN
-        CDB additional sense code.
-        */
-    }
-
-    switch (cmd.page_code) {
-        case scsi_defs::PageCode::kSupportedLogPages:
-            TranslateSupportedLogPages(buffer);
-            break;
-        case scsi_defs::PageCode::kTemperature:
-        // TranslateTemperature(buffer);
-            break;
-        case scsi_defs::PageCode::kSolidStateMedia:
-        // TranslateSolidStateMedia(buffer);
-            break;
-        case scsi_defs::PageCode::kInformationalExceptions:
-        // TranslateInformationalExceptions(buffer);
-            break;
-    }
+  switch (cmd.page_code) {
+    case scsi_defs::PageCode::kSupportedLogPages:
+      TranslateSupportedLogPages(buffer);
+      break;
+    case scsi_defs::PageCode::kTemperature:
+      // TranslateTemperature(buffer);
+      break;
+    case scsi_defs::PageCode::kSolidStateMedia:
+      // TranslateSolidStateMedia(buffer);
+      break;
+    case scsi_defs::PageCode::kInformationalExceptions:
+      // TranslateInformationalExceptions(buffer);
+      break;
+  }
 }
 
 }  // namespace translator

--- a/lib/translator/logsense.cc
+++ b/lib/translator/logsense.cc
@@ -16,14 +16,13 @@
 
 namespace translator {
 
-// Main logic engine for the Inquiry command
-void translate(absl::Span<const uint8_t> raw_cmd, absl::Span<uint8_t> buffer) {
-  scsi_defs::LogSenseCommand cmd;
-//   StatusCode status = RawToScsiCommand(raw_cmd, cmd);
-//   if (status != StatusCode::kSuccess) return;
+void TranslateSupportedLogPages(absl::Span<uint8_t> buffer) {
 
-//   nvme_defs::IdentifyControllerData identify_controller_data;
-//   nvme_defs::IdentifyNamespace identify_namespace_data;
+}
+
+// Main logic engine for the Inquiry command
+void translate(const scsi_defs::LogSenseCommand &cmd, absl::Span<uint8_t> buffer) {
+
     if (cmd.sp == 1 || cmd.pc == 1 || cmd.control_byte.naca == 1) {
         /*
         Command may be terminated with CHECK CONDITION
@@ -31,14 +30,19 @@ void translate(absl::Span<const uint8_t> raw_cmd, absl::Span<uint8_t> buffer) {
         CDB additional sense code.
         */
     }
+
     switch (cmd.page_code) {
         case scsi_defs::PageCode::kSupportedLogPages:
+            TranslateSupportedLogPages(buffer);
             break;
         case scsi_defs::PageCode::kTemperature:
+        // TranslateTemperature(buffer);
             break;
         case scsi_defs::PageCode::kSolidStateMedia:
+        // TranslateSolidStateMedia(buffer);
             break;
         case scsi_defs::PageCode::kInformationalExceptions:
+        // TranslateInformationalExceptions(buffer);
             break;
     }
 }

--- a/lib/translator/logsense.cc
+++ b/lib/translator/logsense.cc
@@ -24,6 +24,23 @@ void translate(absl::Span<const uint8_t> raw_cmd, absl::Span<uint8_t> buffer) {
 
 //   nvme_defs::IdentifyControllerData identify_controller_data;
 //   nvme_defs::IdentifyNamespace identify_namespace_data;
+    if (cmd.sp == 1 || cmd.pc == 1 || cmd.control_byte.naca == 1) {
+        /*
+        Command may be terminated with CHECK CONDITION
+        status, ILLEGAL REQUEST sense key, and ILLEGAL FIELD IN
+        CDB additional sense code.
+        */
+    }
+    switch (cmd.page_code) {
+        case scsi_defs::PageCode::kSupportedLogPages:
+            break;
+        case scsi_defs::PageCode::kTemperature:
+            break;
+        case scsi_defs::PageCode::kSolidStateMedia:
+            break;
+        case scsi_defs::PageCode::kInformationalExceptions:
+            break;
+    }
 }
 
 }  // namespace translator

--- a/lib/translator/logsense.cc
+++ b/lib/translator/logsense.cc
@@ -16,5 +16,14 @@
 
 namespace translator {
 
+// Main logic engine for the Inquiry command
+void translate(absl::Span<const uint8_t> raw_cmd, absl::Span<uint8_t> buffer) {
+  scsi_defs::LogSenseCommand cmd;
+//   StatusCode status = RawToScsiCommand(raw_cmd, cmd);
+//   if (status != StatusCode::kSuccess) return;
+
+//   nvme_defs::IdentifyControllerData identify_controller_data;
+//   nvme_defs::IdentifyNamespace identify_namespace_data;
+}
 
 }  // namespace translator

--- a/lib/translator/logsense.cc
+++ b/lib/translator/logsense.cc
@@ -17,6 +17,17 @@
 namespace translator {
 
 void TranslateSupportedLogPages(absl::Span<uint8_t> buffer) {
+    scsi_defs::SupportedLogPages result = {
+        .page_len = 0x4
+    };
+    scsi_defs::PageCode supported_pages_list[4] = {
+        scsi_defs::PageCode::kSupportedLogPages,
+        scsi_defs::PageCode::kTemperature,
+        scsi_defs::PageCode::kSolidStateMedia,
+        scsi_defs::PageCode::kInformationalExceptions
+    };
+    memcpy(buffer.data(), &result, sizeof(scsi_defs::SupportedLogPages));
+    memcpy(&buffer[sizeof(scsi_defs::SupportedLogPages)], supported_pages_list, sizeof(supported_pages_list));
 
 }
 

--- a/lib/translator/logsense.cc
+++ b/lib/translator/logsense.cc
@@ -1,0 +1,20 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.i// Copyright 2020 Google LLC
+
+#include "logsense.h"
+
+namespace translator {
+
+
+}  // namespace translator

--- a/lib/translator/logsense.cc
+++ b/lib/translator/logsense.cc
@@ -28,7 +28,6 @@ void TranslateSupportedLogPages(absl::Span<uint8_t> buffer) {
     };
     memcpy(buffer.data(), &result, sizeof(scsi_defs::SupportedLogPages));
     memcpy(&buffer[sizeof(scsi_defs::SupportedLogPages)], supported_pages_list, sizeof(supported_pages_list));
-
 }
 
 // Main logic engine for the Inquiry command

--- a/lib/translator/logsense.h
+++ b/lib/translator/logsense.h
@@ -22,11 +22,11 @@
 #include "third_party/spdk_defs/nvme_defs.h"
 
 namespace translator {
-void translate(const scsi_defs::LogSenseCommand &cmd, absl::Span<const uint8_t>);
-    void    TranslateSupportedLogPages(absl::Span<const uint8_t>);
-     void   TranslateTemperature(absl::Span<const uint8_t>);
-     void   TranslateSolidStateMedia(absl::Span<const uint8_t>);
-    void    TranslateInformationalExceptions(absl::Span<const uint8_t>);
+void translate(const scsi_defs::LogSenseCommand &cmd, absl::Span<uint8_t>);
+    void    TranslateSupportedLogPages(absl::Span<uint8_t>);
+     void   TranslateTemperature(absl::Span<uint8_t>);
+     void   TranslateSolidStateMedia(absl::Span<uint8_t>);
+    void    TranslateInformationalExceptions(absl::Span<uint8_t>);
 
 }  // namespace translator
 

--- a/lib/translator/logsense.h
+++ b/lib/translator/logsense.h
@@ -14,14 +14,15 @@
 
 #ifndef LIB_TRANSLATOR_LOGSENSE_H
 #define LIB_TRANSLATOR_LOGSENSE_H
+
 #include "common.h"
 #include "absl/types/span.h"
+#include "absl/strings/string_view.h"
 #include "lib/scsi_defs.h"
 #include "third_party/spdk_defs/nvme_defs.h"
 
 namespace translator {
 void translate(absl::Span<const uint8_t>);
-
 }  // namespace translator
 
 #endif

--- a/lib/translator/logsense.h
+++ b/lib/translator/logsense.h
@@ -15,18 +15,18 @@
 #ifndef LIB_TRANSLATOR_LOGSENSE_H
 #define LIB_TRANSLATOR_LOGSENSE_H
 
-#include "common.h"
-#include "absl/types/span.h"
 #include "absl/strings/string_view.h"
+#include "absl/types/span.h"
+#include "common.h"
 #include "lib/scsi_defs.h"
 #include "third_party/spdk_defs/nvme_defs.h"
 
 namespace translator {
 void translate(const scsi_defs::LogSenseCommand &cmd, absl::Span<uint8_t>);
-    void    TranslateSupportedLogPages(absl::Span<uint8_t>);
-     void   TranslateTemperature(absl::Span<uint8_t>);
-     void   TranslateSolidStateMedia(absl::Span<uint8_t>);
-    void    TranslateInformationalExceptions(absl::Span<uint8_t>);
+void TranslateSupportedLogPages(absl::Span<uint8_t>);
+void TranslateTemperature(absl::Span<uint8_t>);
+void TranslateSolidStateMedia(absl::Span<uint8_t>);
+void TranslateInformationalExceptions(absl::Span<uint8_t>);
 
 }  // namespace translator
 

--- a/lib/translator/logsense.h
+++ b/lib/translator/logsense.h
@@ -1,0 +1,27 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef LIB_TRANSLATOR_LOGSENSE_H
+#define LIB_TRANSLATOR_LOGSENSE_H
+#include "common.h"
+#include "absl/types/span.h"
+#include "lib/scsi_defs.h"
+#include "third_party/spdk_defs/nvme_defs.h"
+
+namespace translator {
+void translate(absl::Span<const uint8_t>);
+
+}  // namespace translator
+
+#endif

--- a/lib/translator/logsense.h
+++ b/lib/translator/logsense.h
@@ -22,7 +22,12 @@
 #include "third_party/spdk_defs/nvme_defs.h"
 
 namespace translator {
-void translate(absl::Span<const uint8_t>);
+void translate(const scsi_defs::LogSenseCommand &cmd, absl::Span<const uint8_t>);
+    void    TranslateSupportedLogPages(absl::Span<const uint8_t>);
+     void   TranslateTemperature(absl::Span<const uint8_t>);
+     void   TranslateSolidStateMedia(absl::Span<const uint8_t>);
+    void    TranslateInformationalExceptions(absl::Span<const uint8_t>);
+
 }  // namespace translator
 
 #endif

--- a/test/translator/BUILD
+++ b/test/translator/BUILD
@@ -6,3 +6,13 @@ cc_test(
     "@googletest//:gtest_main"
   ]
 )
+
+cc_test(
+  name = "logsense_test",
+  srcs = [ "logsense_test.cc" ],
+  deps = [
+    "//lib/translator:common",
+    "//lib/translator:logsense_lib",
+    "@googletest//:gtest_main"
+  ]
+)

--- a/test/translator/logsense_test.cc
+++ b/test/translator/logsense_test.cc
@@ -17,5 +17,18 @@
 #include "gtest/gtest.h"
 
 namespace {
+    TEST(TranslateSupportedLogPages, success) {
+        uint8_t buf[100];
+        absl::Span<uint8_t> span = absl::MakeSpan(buf);
+        translator::TranslateSupportedLogPages(span);
+        const scsi_defs::SupportedLogPages result = *reinterpret_cast<const scsi_defs::SupportedLogPages *>(&buf);
+        const scsi_defs::PageCode *result_list = reinterpret_cast<const scsi_defs::PageCode *>(&buf[sizeof(scsi_defs::SupportedLogPages)]);
+
+        ASSERT_EQ(result.page_len, 0x4);
+        ASSERT_EQ(result_list[0], scsi_defs::PageCode::kSupportedLogPages);
+        ASSERT_EQ(result_list[1], scsi_defs::PageCode::kTemperature);
+        ASSERT_EQ(result_list[2], scsi_defs::PageCode::kSolidStateMedia);
+        ASSERT_EQ(result_list[3], scsi_defs::PageCode::kInformationalExceptions);
+    };
 
 }  // namespace

--- a/test/translator/logsense_test.cc
+++ b/test/translator/logsense_test.cc
@@ -1,0 +1,21 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "lib/translator/common.h"
+#include "lib/translator/logsense.h"
+#include "gtest/gtest.h"
+
+namespace {
+
+}  // namespace

--- a/test/translator/logsense_test.cc
+++ b/test/translator/logsense_test.cc
@@ -12,23 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "lib/translator/common.h"
 #include "lib/translator/logsense.h"
 #include "gtest/gtest.h"
+#include "lib/translator/common.h"
 
 namespace {
-    TEST(TranslateSupportedLogPages, success) {
-        uint8_t buf[100];
-        absl::Span<uint8_t> span = absl::MakeSpan(buf);
-        translator::TranslateSupportedLogPages(span);
-        const scsi_defs::SupportedLogPages result = *reinterpret_cast<const scsi_defs::SupportedLogPages *>(&buf);
-        const scsi_defs::PageCode *result_list = reinterpret_cast<const scsi_defs::PageCode *>(&buf[sizeof(scsi_defs::SupportedLogPages)]);
+TEST(TranslateSupportedLogPages, success) {
+  uint8_t buf[100];
+  absl::Span<uint8_t> span = absl::MakeSpan(buf);
+  translator::TranslateSupportedLogPages(span);
+  const scsi_defs::SupportedLogPages result =
+      *reinterpret_cast<const scsi_defs::SupportedLogPages *>(&buf);
+  const scsi_defs::PageCode *result_list =
+      reinterpret_cast<const scsi_defs::PageCode *>(
+          &buf[sizeof(scsi_defs::SupportedLogPages)]);
 
-        ASSERT_EQ(result.page_len, 0x4);
-        ASSERT_EQ(result_list[0], scsi_defs::PageCode::kSupportedLogPages);
-        ASSERT_EQ(result_list[1], scsi_defs::PageCode::kTemperature);
-        ASSERT_EQ(result_list[2], scsi_defs::PageCode::kSolidStateMedia);
-        ASSERT_EQ(result_list[3], scsi_defs::PageCode::kInformationalExceptions);
-    };
+  ASSERT_EQ(result.page_len, 0x4);
+  ASSERT_EQ(result_list[0], scsi_defs::PageCode::kSupportedLogPages);
+  ASSERT_EQ(result_list[1], scsi_defs::PageCode::kTemperature);
+  ASSERT_EQ(result_list[2], scsi_defs::PageCode::kSolidStateMedia);
+  ASSERT_EQ(result_list[3], scsi_defs::PageCode::kInformationalExceptions);
+};
 
 }  // namespace


### PR DESCRIPTION
NOTE: This command is not prioritized and will probably not be worked on any time soon. 

The Log Sense data returns extra information about the device such as Temperature. This PR was not deleted in case Log Sense is picked up again in the future.