### PR TITLE
implement htonll for uint64_t

### DIFF
--- a/lib/translator/common.cc
+++ b/lib/translator/common.cc
@@ -75,21 +75,6 @@ uint64_t htonll(uint64_t value) {
   }
 }
 
-uint64_t ntohll(uint64_t value) {
-  static uint32_t test_val = 42;
-
-  // Check first byte to determine endianness
-  if (*reinterpret_cast<const char*>(&test_val) == test_val) {  // little endian
-    const uint32_t high_bits = htonl(static_cast<uint32_t>(value >> 32));
-    const uint32_t low_bits =
-        htonl(static_cast<uint32_t>(value & 0xFFFFFFFFLL));
-
-    return (static_cast<uint64_t>(low_bits) << 32) | high_bits;
-  } else {  // big endian
-    return value;
-  }
-}
-
 StatusCode Allocation::SetPages(uint16_t data_page_count,
                                 uint16_t mdata_page_count) {
   if ((data_page_count != 0 && this->data_addr != 0) ||

--- a/lib/translator/common.cc
+++ b/lib/translator/common.cc
@@ -64,13 +64,28 @@ uint64_t htonll(uint64_t value) {
   static uint32_t test_val = 42;
 
   // Check first byte to determine endianness
-  if (*reinterpret_cast<const char*>(&test_val) == test_val) {
+  if (*reinterpret_cast<const char*>(&test_val) == test_val) {  // little endian
     const uint32_t high_bits = htonl(static_cast<uint32_t>(value >> 32));
     const uint32_t low_bits =
         htonl(static_cast<uint32_t>(value & 0xFFFFFFFFLL));
 
     return (static_cast<uint64_t>(low_bits) << 32) | high_bits;
-  } else {
+  } else {  // big endian
+    return value;
+  }
+}
+
+uint64_t ntohll(uint64_t value) {
+  static uint32_t test_val = 42;
+
+  // Check first byte to determine endianness
+  if (*reinterpret_cast<const char*>(&test_val) == test_val) {  // little endian
+    const uint32_t high_bits = htonl(static_cast<uint32_t>(value >> 32));
+    const uint32_t low_bits =
+        htonl(static_cast<uint32_t>(value & 0xFFFFFFFFLL));
+
+    return (static_cast<uint64_t>(low_bits) << 32) | high_bits;
+  } else {  // big endian
     return value;
   }
 }

--- a/lib/translator/common.cc
+++ b/lib/translator/common.cc
@@ -14,7 +14,12 @@
 
 #include "common.h"
 
+#ifdef __KERNEL__
+#include <linux/byteorder/generic.h>
+#else
 #include <netinet/in.h>
+#endif
+
 #include <stdarg.h>
 #include <stdio.h>
 

--- a/lib/translator/common.cc
+++ b/lib/translator/common.cc
@@ -61,7 +61,7 @@ void SetAllocPageCallbacks(uint64_t (*alloc_callback)(uint16_t),
 }
 
 uint64_t htonll(uint64_t value) {
-  static int test_val = 42;
+  static uint32_t test_val = 42;
 
   // Check first byte to determine endianness
   if (*reinterpret_cast<const char*>(&test_val) == test_val) {

--- a/lib/translator/common.cc
+++ b/lib/translator/common.cc
@@ -56,7 +56,7 @@ void SetAllocPageCallbacks(uint64_t (*alloc_callback)(uint16_t),
 }
 
 uint64_t htonll(uint64_t value) {
-  static int test_val = 1337;
+  static int test_val = 42;
 
   // Check first byte to determine endianness
   if (*reinterpret_cast<const char*>(&test_val) == test_val) {

--- a/lib/translator/common.cc
+++ b/lib/translator/common.cc
@@ -14,6 +14,7 @@
 
 #include "common.h"
 
+#include <netinet/in.h>
 #include <stdarg.h>
 #include <stdio.h>
 
@@ -52,6 +53,21 @@ void SetAllocPageCallbacks(uint64_t (*alloc_callback)(uint16_t),
                            void (*dealloc_callback)(uint64_t, uint16_t)) {
   alloc_pages_callback = alloc_callback;
   dealloc_pages_callback = dealloc_callback;
+}
+
+uint64_t htonll(uint64_t value) {
+  static int test_val = 1337;
+
+  // Check first byte to determine endianness
+  if (*reinterpret_cast<const char*>(&test_val) == test_val) {
+    const uint32_t high_bits = htonl(static_cast<uint32_t>(value >> 32));
+    const uint32_t low_bits =
+        htonl(static_cast<uint32_t>(value & 0xFFFFFFFFLL));
+
+    return (static_cast<uint64_t>(low_bits) << 32) | high_bits;
+  } else {
+    return value;
+  }
 }
 
 const char* ScsiOpcodeToString(scsi::OpCode opcode) {

--- a/lib/translator/common.h
+++ b/lib/translator/common.h
@@ -57,6 +57,8 @@ void SetDebugCallback(void (*callback)(const char*));
 void SetAllocPageCallbacks(uint64_t (*alloc_callback)(uint16_t),
                            void (*dealloc_callback)(uint64_t, uint16_t));
 
+uint64_t htonll(uint64_t value);
+
 // does not return string_view for compatibility with DebugLog
 const char* ScsiOpcodeToString(scsi::OpCode opcode);
 

--- a/lib/translator/common.h
+++ b/lib/translator/common.h
@@ -61,6 +61,11 @@ void SetDebugCallback(void (*callback)(const char*));
 void SetAllocPageCallbacks(uint64_t (*alloc_callback)(uint16_t),
                            void (*dealloc_callback)(uint64_t, uint16_t));
 
+// Host to Network endianness transformation for uint64_t
+// Network endianness is always big endian
+// Converts value to big endian if Host is little endian
+// No op if Host is big endian
+// Intended use: ensuring SCSI commands are in big endian
 uint64_t htonll(uint64_t value);
 
 // does not return string_view for compatibility with DebugLog

--- a/lib/translator/common.h
+++ b/lib/translator/common.h
@@ -65,8 +65,13 @@ void SetAllocPageCallbacks(uint64_t (*alloc_callback)(uint16_t),
 // Network endianness is always big endian
 // Converts value to big endian if Host is little endian
 // No op if Host is big endian
-// Intended use: ensuring SCSI commands are in big endian
 uint64_t htonll(uint64_t value);
+
+// Network to Host endianness transformation for uint64_t
+// Network endianness is always big endian
+// Converts value to little endian if Host is little endian
+// No op if Host is big endian
+uint64_t ntohll(uint64_t value);
 
 // does not return string_view for compatibility with DebugLog
 const char* ScsiOpcodeToString(scsi::OpCode opcode);

--- a/lib/translator/common.h
+++ b/lib/translator/common.h
@@ -71,7 +71,7 @@ uint64_t htonll(uint64_t value);
 // Network endianness is always big endian
 // Converts value to little endian if Host is little endian
 // No op if Host is big endian
-uint64_t ntohll(uint64_t value);
+#define ntohll htonll
 
 // does not return string_view for compatibility with DebugLog
 const char* ScsiOpcodeToString(scsi::OpCode opcode);


### PR DESCRIPTION
We currently use `htonl()` and `htons()` to ensure our SCSI structs are in big endian. However, there is currently no function for `uint64_t` which is the data type for some SCSI fields such as `logical_block_address`. 

`htonll()` first checks whether the machine is in big endian and then does the transformation if not. 