### PR TITLE
Remove Problematic STL Includes

### DIFF
--- a/lib/translator/BUILD
+++ b/lib/translator/BUILD
@@ -6,9 +6,6 @@ cc_library(
       "//third_party/spdk:nvme_lib",
       "//lib:scsi_lib",
       ":common",
-      "@com_google_absl//absl/base",
-      "@com_google_absl//absl/types:span",
-      "@com_google_absl//absl/strings",
   ],
   visibility = ["//visibility:public"],
 )
@@ -20,9 +17,7 @@ cc_library(
   deps = [
     "//third_party/spdk:nvme_lib",
     "//lib:scsi_lib",
-    "@com_google_absl//absl/types:span",
     "@com_google_absl//absl/base",
-    "@com_google_absl//absl/strings",
   ],
   visibility = ["//visibility:public"],
 )
@@ -33,7 +28,6 @@ cc_library(
   srcs = ["translation.cc"],
   deps = [
     ":request_sense_lib",
-    "@com_google_absl//absl/types:span",
     ":common",
     ":inquiry_lib"
   ],
@@ -48,7 +42,6 @@ cc_library(
       "//third_party/spdk:nvme_lib",
       "//lib:scsi_lib",
       ":common",
-      "@com_google_absl//absl/base",
   ],
   visibility = ["//visibility:public"],
 )
@@ -61,7 +54,6 @@ cc_library(
       "//third_party/spdk:nvme_lib",
       "//lib:scsi_lib",
       ":common",
-      "@com_google_absl//absl/base",
   ],
   visibility = ["//visibility:public"],
 )

--- a/lib/translator/common.h
+++ b/lib/translator/common.h
@@ -73,8 +73,8 @@ class Span {
   Span(T* ptr, size_t len) : ptr_(ptr), len_(len) {}
   template <size_t N>
   Span(T (&a)[N]) : Span(a, N) {}
-  template <typename Y,
-            typename = std::enable_if<std::is_convertible<T*, Y*>::value>>
+  template <typename Y, typename = std::enable_if<std::is_same<
+                            typename std::decay<T*>::type, Y*>::value>>
   Span(const Span<Y>& ref) : Span(ref.data(), ref.size()) {}
   T* data() const { return ptr_; }
   size_t size() const { return len_; }

--- a/lib/translator/common.h
+++ b/lib/translator/common.h
@@ -73,7 +73,8 @@ class Span {
   Span(T* ptr, size_t len) : ptr_(ptr), len_(len) {}
   template <size_t N>
   Span(T (&a)[N]) : Span(a, N) {}
-  template <typename Y>
+  template <typename Y,
+            typename = std::enable_if<std::is_convertible<T*, Y*>::value>>
   Span(const Span<Y>& ref) : Span(ref.data(), ref.size()) {}
   T* data() const { return ptr_; }
   size_t size() const { return len_; }

--- a/lib/translator/inquiry.cc
+++ b/lib/translator/inquiry.cc
@@ -337,10 +337,10 @@ StatusCode InquiryToScsi(Span<const uint8_t> raw_scsi, Span<uint8_t> buffer,
   };
 
   uint8_t* ctrl_dptr = reinterpret_cast<uint8_t*>(nvme_cmds[0].dptr.prp.prp1);
-  Span ctrl_span(ctrl_dptr, sizeof(nvme::IdentifyControllerData));
+  Span<uint8_t> ctrl_span(ctrl_dptr, sizeof(nvme::IdentifyControllerData));
 
   uint8_t* ns_dptr = reinterpret_cast<uint8_t*>(nvme_cmds[1].dptr.prp.prp1);
-  Span ns_span(ns_dptr, sizeof(nvme::IdentifyNamespace));
+  Span<uint8_t> ns_span(ns_dptr, sizeof(nvme::IdentifyNamespace));
 
   nvme::IdentifyControllerData identify_ctrl = {};
   if (!ReadValue(ctrl_span, identify_ctrl)) {

--- a/lib/translator/inquiry.cc
+++ b/lib/translator/inquiry.cc
@@ -22,7 +22,7 @@ namespace translator {
 namespace {
 void TranslateStandardInquiry(const nvme::IdentifyControllerData& identify_ctrl,
                               const nvme::IdentifyNamespace& identify_ns,
-                              absl::Span<uint8_t> buffer) {
+                              Span<uint8_t> buffer) {
   scsi::InquiryData result = {
       .version = scsi::Version::kSpc4,
       .response_data_format = scsi::ResponseDataFormat::kCompliant,
@@ -35,10 +35,10 @@ void TranslateStandardInquiry(const nvme::IdentifyControllerData& identify_ctrl,
   // Shall be set to “NVMe" followed by 4 spaces: “NVMe    “
   // Vendor Identification is not null terminated.
   static_assert(sizeof(result.vendor_identification) ==
-                kNvmeVendorIdentification.size());
+                strlen(kNvmeVendorIdentification));
 
-  memcpy(result.vendor_identification, kNvmeVendorIdentification.data(),
-         kNvmeVendorIdentification.size());
+  memcpy(result.vendor_identification, kNvmeVendorIdentification,
+         strlen(kNvmeVendorIdentification));
 
   // Shall be set to the first 16 bytes of the Model Number (MN) field within
   // the Identify Controller Data Structure
@@ -59,7 +59,7 @@ void TranslateStandardInquiry(const nvme::IdentifyControllerData& identify_ctrl,
   WriteValue(result, buffer);
 }
 
-void TranslateSupportedVpdPages(absl::Span<uint8_t> buffer) {
+void TranslateSupportedVpdPages(Span<uint8_t> buffer) {
   scsi::PageCode supported_page_list[7] = {
       scsi::PageCode::kSupportedVpd,
       scsi::PageCode::kUnitSerialNumber,
@@ -80,7 +80,7 @@ void TranslateSupportedVpdPages(absl::Span<uint8_t> buffer) {
 void TranslateUnitSerialNumberVpd(
     const nvme::IdentifyControllerData& identify_ctrl,
     const nvme::IdentifyNamespace& identify_ns, uint32_t nsid,
-    absl::Span<uint8_t> buffer) {
+    Span<uint8_t> buffer) {
   scsi::UnitSerialNumber result = {.page_code =
                                        scsi::PageCode::kUnitSerialNumber};
 
@@ -154,7 +154,7 @@ void TranslateUnitSerialNumberVpd(
 }
 
 void TranslateBlockLimitsVpd(const nvme::IdentifyControllerData& identify_ctrl,
-                             absl::Span<uint8_t> buffer) {
+                             Span<uint8_t> buffer) {
   // The value is in units of the minimum memory
   // page size (CAP.MPSMIN) and is reported as a power of two (2^n).
   // A value of 0h indicates that there is no maximum data transfer size
@@ -214,7 +214,7 @@ void TranslateBlockLimitsVpd(const nvme::IdentifyControllerData& identify_ctrl,
 
 void TranslateLogicalBlockProvisioningVpd(
     const nvme::IdentifyControllerData& identify_ctrl,
-    const nvme::IdentifyNamespace& identify_ns, absl::Span<uint8_t> buffer) {
+    const nvme::IdentifyNamespace& identify_ns, Span<uint8_t> buffer) {
   bool ad = identify_ctrl.oncs.dsm;
 
   scsi::LogicalBlockProvisioningVpd result = {
@@ -286,11 +286,11 @@ void TranslateLogicalBlockProvisioningVpd(
 
 }  // namespace
 
-StatusCode InquiryToNvme(absl::Span<const uint8_t> raw_scsi,
+StatusCode InquiryToNvme(Span<const uint8_t> raw_scsi,
                          nvme::GenericQueueEntryCmd& identify_ns,
                          nvme::GenericQueueEntryCmd& identify_ctrl,
                          uint32_t& alloc_len, scsi::LunAddress lun,
-                         absl::Span<Allocation> allocations) {
+                         Span<Allocation> allocations) {
   scsi::InquiryCommand cmd = {};
   if (!ReadValue(raw_scsi, cmd)) {
     DebugLog("Malformed Inquiry Command");
@@ -323,9 +323,8 @@ StatusCode InquiryToNvme(absl::Span<const uint8_t> raw_scsi,
 }
 
 // Main logic engine for the Inquiry command
-StatusCode InquiryToScsi(
-    absl::Span<const uint8_t> raw_scsi, absl::Span<uint8_t> buffer,
-    absl::Span<const nvme::GenericQueueEntryCmd> nvme_cmds) {
+StatusCode InquiryToScsi(Span<const uint8_t> raw_scsi, Span<uint8_t> buffer,
+                         Span<const nvme::GenericQueueEntryCmd> nvme_cmds) {
   scsi::InquiryCommand inquiry_cmd = {};
 
   if (!ReadValue(raw_scsi, inquiry_cmd)) {
@@ -334,11 +333,10 @@ StatusCode InquiryToScsi(
   };
 
   uint8_t* ctrl_dptr = reinterpret_cast<uint8_t*>(nvme_cmds[0].dptr.prp.prp1);
-  auto ctrl_span =
-      absl::MakeSpan(ctrl_dptr, sizeof(nvme::IdentifyControllerData));
+  Span ctrl_span(ctrl_dptr, sizeof(nvme::IdentifyControllerData));
 
   uint8_t* ns_dptr = reinterpret_cast<uint8_t*>(nvme_cmds[1].dptr.prp.prp1);
-  auto ns_span = absl::MakeSpan(ns_dptr, sizeof(nvme::IdentifyNamespace));
+  Span ns_span(ns_dptr, sizeof(nvme::IdentifyNamespace));
 
   nvme::IdentifyControllerData identify_ctrl = {};
   if (!ReadValue(ctrl_span, identify_ctrl)) {

--- a/lib/translator/inquiry.h
+++ b/lib/translator/inquiry.h
@@ -19,8 +19,6 @@
 
 #include "common.h"
 #include "lib/scsi.h"
-
-#include "absl/types/span.h"
 #include "third_party/spdk/nvme.h"
 
 namespace translator {
@@ -33,11 +31,11 @@ namespace translator {
 // Postconditions:
 // Fills out GenericQueueEntryCmd with appropriate Identify parameters and
 // allocates PRPs for responses
-StatusCode InquiryToNvme(absl::Span<const uint8_t> scsi_cmd,
+StatusCode InquiryToNvme(Span<const uint8_t> scsi_cmd,
                          nvme::GenericQueueEntryCmd& identify_ns,
                          nvme::GenericQueueEntryCmd& identify_ctrl,
                          uint32_t& alloc_len, scsi::LunAddress lun,
-                         absl::Span<Allocation> allocations);
+                         Span<Allocation> allocations);
 
 // Preconditions:
 // scsi_cmd is a pointer to a Inquiry Command without the OpCode
@@ -46,9 +44,8 @@ StatusCode InquiryToNvme(absl::Span<const uint8_t> scsi_cmd,
 
 // Postconditions:
 // buffer contains SCSI response based on scsi_cmd parameters
-StatusCode InquiryToScsi(
-    absl::Span<const uint8_t> scsi_cmd, absl::Span<uint8_t> buffer,
-    absl::Span<const nvme::GenericQueueEntryCmd> nvme_cmds);
+StatusCode InquiryToScsi(Span<const uint8_t> scsi_cmd, Span<uint8_t> buffer,
+                         Span<const nvme::GenericQueueEntryCmd> nvme_cmds);
 
 };  // namespace translator
 #endif

--- a/lib/translator/read_capacity_10.cc
+++ b/lib/translator/read_capacity_10.cc
@@ -16,7 +16,7 @@
 
 namespace translator {
 
-StatusCode ReadCapacity10ToNvme(absl::Span<const uint8_t> raw_scsi,
+StatusCode ReadCapacity10ToNvme(Span<const uint8_t> raw_scsi,
                                 nvme::GenericQueueEntryCmd& identify_ns,
                                 scsi::LunAddress lun, Allocation allocation) {
   scsi::ReadCapacity10Command cmd = {};
@@ -46,10 +46,10 @@ StatusCode ReadCapacity10ToNvme(absl::Span<const uint8_t> raw_scsi,
   return StatusCode::kSuccess;
 }
 
-StatusCode ReadCapacity10ToScsi(absl::Span<uint8_t> buffer,
+StatusCode ReadCapacity10ToScsi(Span<uint8_t> buffer,
                                 nvme::GenericQueueEntryCmd gen_identify_ns) {
   uint8_t* ns_dptr = reinterpret_cast<uint8_t*>(gen_identify_ns.dptr.prp.prp1);
-  auto ns_span = absl::MakeSpan(ns_dptr, sizeof(nvme::IdentifyNamespace));
+  Span<uint8_t> ns_span(ns_dptr, sizeof(nvme::IdentifyNamespace));
 
   nvme::IdentifyNamespace identify_ns = {};
   if (!ReadValue(ns_span, identify_ns)) {

--- a/lib/translator/read_capacity_10.h
+++ b/lib/translator/read_capacity_10.h
@@ -15,19 +15,17 @@
 #ifndef LIB_TRANSLATOR_READ_CAPACITY_10_H
 #define LIB_TRANSLATOR_READ_CAPACITY_10_H
 
-#include "absl/types/span.h"
-#include "third_party/spdk/nvme.h"
-
 #include "common.h"
 #include "lib/scsi.h"
+#include "third_party/spdk/nvme.h"
 
 namespace translator {
 
-StatusCode ReadCapacity10ToNvme(absl::Span<const uint8_t> raw_scsi,
+StatusCode ReadCapacity10ToNvme(Span<const uint8_t> raw_scsi,
                                 nvme::GenericQueueEntryCmd& identify_ns,
                                 scsi::LunAddress lun, Allocation allocation);
 
-StatusCode ReadCapacity10ToScsi(absl::Span<uint8_t> buffer,
+StatusCode ReadCapacity10ToScsi(Span<uint8_t> buffer,
                                 nvme::GenericQueueEntryCmd gen_identify_ns);
 
 };  // namespace translator

--- a/lib/translator/request_sense.cc
+++ b/lib/translator/request_sense.cc
@@ -17,7 +17,7 @@
 namespace translator {
 
 namespace {  // anonymous namespace for helper functions
-void TranslateDescriptorSenseData(absl::Span<uint8_t> buffer) {
+void TranslateDescriptorSenseData(Span<uint8_t> buffer) {
   scsi::DescriptorFormatSenseData result = {
       // Shall be set to 72h indicating current errors are returned.
       .response_code = 0x72,
@@ -31,7 +31,7 @@ void TranslateDescriptorSenseData(absl::Span<uint8_t> buffer) {
   WriteValue(result, buffer);
 }
 
-void TranslateFixedSenseData(absl::Span<uint8_t> buffer) {
+void TranslateFixedSenseData(Span<uint8_t> buffer) {
   scsi::FixedFormatSenseData result = {
       // Shall be set to 70h indicating current errors are returned.
       .response_code = 0x70,
@@ -58,7 +58,7 @@ void TranslateFixedSenseData(absl::Span<uint8_t> buffer) {
 
 }  // namespace
 
-StatusCode RequestSenseToNvme(absl::Span<const uint8_t> scsi_cmd,
+StatusCode RequestSenseToNvme(Span<const uint8_t> scsi_cmd,
                               uint32_t& allocation_length) {
   scsi::RequestSenseCommand request_sense_cmd{};
   if (!ReadValue(scsi_cmd, request_sense_cmd)) {
@@ -74,8 +74,8 @@ StatusCode RequestSenseToNvme(absl::Span<const uint8_t> scsi_cmd,
   return StatusCode::kSuccess;
 }
 
-StatusCode RequestSenseToScsi(absl::Span<const uint8_t> scsi_cmd,
-                              absl::Span<uint8_t> buffer) {
+StatusCode RequestSenseToScsi(Span<const uint8_t> scsi_cmd,
+                              Span<uint8_t> buffer) {
   scsi::RequestSenseCommand request_sense_cmd{};
   if (!ReadValue(scsi_cmd, request_sense_cmd)) {
     DebugLog("Malformed RequestSense Command");

--- a/lib/translator/request_sense.h
+++ b/lib/translator/request_sense.h
@@ -18,18 +18,17 @@
 #include <cstring>
 #include <type_traits>
 
-#include "absl/types/span.h"
 #include "common.h"
 
 #include "lib/scsi.h"
 #include "third_party/spdk/nvme.h"
 
 namespace translator {
-StatusCode RequestSenseToNvme(absl::Span<const uint8_t> scsi_cmd,
+StatusCode RequestSenseToNvme(Span<const uint8_t> scsi_cmd,
                               uint32_t& allocation_length);
 
-StatusCode RequestSenseToScsi(absl::Span<const uint8_t> scsi_cmd,
-                              absl::Span<uint8_t> buffer);
+StatusCode RequestSenseToScsi(Span<const uint8_t> scsi_cmd,
+                              Span<uint8_t> buffer);
 
 }  // namespace translator
 #endif

--- a/lib/translator/translation.cc
+++ b/lib/translator/translation.cc
@@ -19,7 +19,7 @@
 
 namespace translator {
 
-BeginResponse Translation::Begin(absl::Span<const uint8_t> scsi_cmd,
+BeginResponse Translation::Begin(Span<const uint8_t> scsi_cmd,
                                  scsi::LunAddress lun) {
   BeginResponse response = {};
   response.status = ApiStatus::kSuccess;
@@ -39,7 +39,7 @@ BeginResponse Translation::Begin(absl::Span<const uint8_t> scsi_cmd,
   pipeline_status_ = StatusCode::kSuccess;
   scsi_cmd_ = scsi_cmd;
 
-  absl::Span<const uint8_t> scsi_cmd_no_op = scsi_cmd.subspan(1);
+  Span<const uint8_t> scsi_cmd_no_op = scsi_cmd.subspan(1);
   scsi::OpCode opc = static_cast<scsi::OpCode>(scsi_cmd[0]);
   switch (opc) {
     case scsi::OpCode::kInquiry:
@@ -63,9 +63,8 @@ BeginResponse Translation::Begin(absl::Span<const uint8_t> scsi_cmd,
   return response;
 }
 
-ApiStatus Translation::Complete(
-    absl::Span<const nvme::GenericQueueEntryCpl> cpl_data,
-    absl::Span<uint8_t> buffer) {
+ApiStatus Translation::Complete(Span<const nvme::GenericQueueEntryCpl> cpl_data,
+                                Span<uint8_t> buffer) {
   if (pipeline_status_ == StatusCode::kUninitialized) {
     DebugLog("Invalid use of API: Complete called before Begin");
     return ApiStatus::kFailure;
@@ -78,7 +77,7 @@ ApiStatus Translation::Complete(
 
   // Switch cases should not return
   ApiStatus ret;
-  absl::Span<const uint8_t> scsi_cmd_no_op = scsi_cmd_.subspan(1);
+  Span<const uint8_t> scsi_cmd_no_op = scsi_cmd_.subspan(1);
   scsi::OpCode opc = static_cast<scsi::OpCode>(scsi_cmd_[0]);
   switch (opc) {
     case scsi::OpCode::kInquiry:
@@ -94,8 +93,8 @@ ApiStatus Translation::Complete(
   return ret;
 }
 
-absl::Span<const nvme::GenericQueueEntryCmd> Translation::GetNvmeCmds() {
-  return absl::MakeSpan(nvme_cmds_, nvme_cmd_count_);
+Span<const nvme::GenericQueueEntryCmd> Translation::GetNvmeCmds() {
+  return Span(nvme_cmds_, nvme_cmd_count_);
 }
 
 void Translation::AbortPipeline() {

--- a/lib/translator/translation.h
+++ b/lib/translator/translation.h
@@ -15,8 +15,6 @@
 #ifndef LIB_TRANSLATOR_TRANSLATION_H
 #define LIB_TRANSLATOR_TRANSLATION_H
 
-#include "absl/types/span.h"
-
 #include "common.h"
 
 namespace translator {

--- a/lib/translator/translation.h
+++ b/lib/translator/translation.h
@@ -37,12 +37,12 @@ class Translation {
         allocations_() {}
   // Translates from SCSI to NVMe. Translated commands available through
   // GetNvmeCmds()
-  BeginResponse Begin(absl::Span<const uint8_t> scsi_cmd, scsi::LunAddress lun);
+  BeginResponse Begin(Span<const uint8_t> scsi_cmd, scsi::LunAddress lun);
   // Translates from NVMe to SCSI. Writes SCSI response data to buffer.
-  ApiStatus Complete(absl::Span<const nvme::GenericQueueEntryCpl> cpl_data,
-                     absl::Span<uint8_t> buffer);
+  ApiStatus Complete(Span<const nvme::GenericQueueEntryCpl> cpl_data,
+                     Span<uint8_t> buffer);
   // Returns a span containing translated NVMe commands.
-  absl::Span<const nvme::GenericQueueEntryCmd> GetNvmeCmds();
+  Span<const nvme::GenericQueueEntryCmd> GetNvmeCmds();
   // Aborts a given pipeline sequence and cleans up memory
   void AbortPipeline();
 
@@ -52,7 +52,7 @@ class Translation {
 
  private:
   StatusCode pipeline_status_;
-  absl::Span<const uint8_t> scsi_cmd_;
+  Span<const uint8_t> scsi_cmd_;
   uint32_t nvme_cmd_count_;
   nvme::GenericQueueEntryCmd nvme_cmds_[kMaxCommandRatio];
   Allocation allocations_[kMaxCommandRatio];

--- a/test/translator/common_test.cc
+++ b/test/translator/common_test.cc
@@ -14,7 +14,6 @@
 
 #include "lib/translator/common.h"
 
-#include "absl/types/span.h"
 #include "gtest/gtest.h"
 #include "lib/scsi.h"
 

--- a/test/translator/inquiry_test.cc
+++ b/test/translator/inquiry_test.cc
@@ -24,8 +24,8 @@ class InquiryTest : public ::testing::Test {
  protected:
   scsi::InquiryCommand inquiry_cmd_;
   nvme::GenericQueueEntryCmd identify_cmds_[2];
-  absl::Span<const uint8_t> scsi_cmd_;
-  absl::Span<nvme::GenericQueueEntryCmd> nvme_cmds_;
+  translator::Span<const uint8_t> scsi_cmd_;
+  translator::Span<nvme::GenericQueueEntryCmd> nvme_cmds_;
   nvme::IdentifyControllerData identify_ctrl_;
   nvme::IdentifyNamespace identify_ns_;
   uint8_t buffer_[200];
@@ -56,7 +56,7 @@ class InquiryTest : public ::testing::Test {
 
   void SetCommand() {
     const uint8_t* cmd_ptr = reinterpret_cast<const uint8_t*>(&inquiry_cmd_);
-    scsi_cmd_ = absl::MakeSpan(cmd_ptr, sizeof(scsi::InquiryCommand));
+    scsi_cmd_ = translator::Span(cmd_ptr, sizeof(scsi::InquiryCommand));
   }
 
   void SetController(nvme::IdentifyControllerData* identify_ctrl_) {
@@ -202,7 +202,7 @@ TEST_F(InquiryTest, SupportedVpdPages) {
       scsi::PageCode::kLogicalBlockProvisioningVpd};
 
   scsi::PageCode result_list[7];
-  absl::Span<uint8_t> span_buffer = buffer_;
+  translator::Span<uint8_t> span_buffer = buffer_;
   EXPECT_TRUE(translator::ReadValue(
       span_buffer.subspan(sizeof(scsi::SupportedVitalProductData)),
       result_list));
@@ -238,7 +238,7 @@ TEST_F(InquiryTest, TranslateUnitSerialNumberVpdEui64) {
   EXPECT_EQ(result.page_code, scsi::PageCode::kUnitSerialNumber);
   EXPECT_EQ(result.page_length, 20);
 
-  absl::Span<uint8_t> span_buffer = buffer_;
+  translator::Span<uint8_t> span_buffer = buffer_;
   uint8_t product_serial_number[20];
   EXPECT_TRUE(
       translator::ReadValue(span_buffer.subspan(sizeof(scsi::UnitSerialNumber)),
@@ -272,7 +272,7 @@ TEST_F(InquiryTest, TranslateUnitSerialNumberVpdNguid) {
   EXPECT_EQ(result.page_code, scsi::PageCode::kUnitSerialNumber);
   EXPECT_EQ(result.page_length, 40);
   char formatted_hex_string[41] = "1234_5678_9abc_defa_1234_5678_9abc_defa.";
-  absl::Span<uint8_t> span_buffer = buffer_;
+  translator::Span<uint8_t> span_buffer = buffer_;
   uint8_t product_serial_number[40];
   EXPECT_TRUE(
       translator::ReadValue(span_buffer.subspan(sizeof(scsi::UnitSerialNumber)),
@@ -306,7 +306,7 @@ TEST_F(InquiryTest, TranslateUnitSerialNumberVpdBoth) {
   EXPECT_EQ(result.page_length, 40);
   char formatted_hex_string[41] = "1234_5678_9abc_defa_1234_5678_9abc_defa.";
 
-  absl::Span<uint8_t> span_buffer = buffer_;
+  translator::Span<uint8_t> span_buffer = buffer_;
   uint8_t product_serial_number[40];
   EXPECT_TRUE(
       translator::ReadValue(span_buffer.subspan(sizeof(scsi::UnitSerialNumber)),
@@ -340,7 +340,7 @@ TEST_F(InquiryTest, TranslateUnitSerialNumberVpdNone) {
   EXPECT_EQ(result.page_code, scsi::PageCode::kUnitSerialNumber);
   EXPECT_EQ(result.page_length, 30);
 
-  absl::Span<uint8_t> span_buffer = buffer_;
+  translator::Span<uint8_t> span_buffer = buffer_;
   uint8_t product_serial_number[30];
   EXPECT_TRUE(
       translator::ReadValue(span_buffer.subspan(sizeof(scsi::UnitSerialNumber)),

--- a/test/translator/read_capacity_10_test.cc
+++ b/test/translator/read_capacity_10_test.cc
@@ -21,8 +21,8 @@ class ReadCapacity10Test : public ::testing::Test {
  protected:
   scsi::ReadCapacity10Command read_capacity_10_cmd_;
   nvme::GenericQueueEntryCmd identify_cmds_[1];
-  absl::Span<nvme::GenericQueueEntryCmd> nvme_cmds_;
-  absl::Span<const uint8_t> scsi_cmd_;
+  translator::Span<nvme::GenericQueueEntryCmd> nvme_cmds_;
+  translator::Span<const uint8_t> scsi_cmd_;
   nvme::IdentifyNamespace identify_ns_;
 
   uint8_t buffer_[200];
@@ -53,7 +53,8 @@ class ReadCapacity10Test : public ::testing::Test {
   void SetCommand() {
     const uint8_t* cmd_ptr =
         reinterpret_cast<const uint8_t*>(&read_capacity_10_cmd_);
-    scsi_cmd_ = absl::MakeSpan(cmd_ptr, sizeof(scsi::ReadCapacity10Command));
+    scsi_cmd_ = translator::Span<const uint8_t>(
+        cmd_ptr, sizeof(scsi::ReadCapacity10Command));
   }
 
   void SetNamespace(nvme::IdentifyNamespace* identify_ns_) {

--- a/test/translator/request_sense_test.cc
+++ b/test/translator/request_sense_test.cc
@@ -23,8 +23,8 @@ TEST(RequestSense, ToNvmeSuccess) {
   };
   uint32_t allocation_length = 0;
   const uint8_t* ptr = reinterpret_cast<const uint8_t*>(&request_sense_cmd);
-  absl::Span<const uint8_t> scsi_cmd =
-      absl::MakeSpan(ptr, sizeof(scsi::RequestSenseCommand));
+  translator::Span<const uint8_t> scsi_cmd(ptr,
+                                           sizeof(scsi::RequestSenseCommand));
   EXPECT_EQ(translator::RequestSenseToNvme(scsi_cmd, allocation_length),
             translator::StatusCode::kSuccess);
   EXPECT_EQ(allocation_length, request_sense_cmd.allocation_length);
@@ -38,7 +38,7 @@ TEST(RequestSense, ToNvmeBadBuffer) {
   };
   uint32_t allocation_length = 0;
   const uint8_t* ptr = reinterpret_cast<const uint8_t*>(&request_sense_cmd);
-  absl::Span<const uint8_t> scsi_cmd = absl::MakeSpan(ptr, sizeof(1));
+  translator::Span<const uint8_t> scsi_cmd(ptr, sizeof(1));
   EXPECT_EQ(translator::RequestSenseToNvme(scsi_cmd, allocation_length),
             translator::StatusCode::kInvalidInput);
   EXPECT_EQ(allocation_length, 0);
@@ -47,9 +47,9 @@ TEST(RequestSense, ToNvmeBadBuffer) {
 TEST(RequestSense, ToScsiBadBuffer) {
   const scsi::RequestSenseCommand request_sense_cmd{};
   uint8_t buf[100];
-  absl::Span<uint8_t> buffer = buf;
+  translator::Span<uint8_t> buffer = buf;
   const uint8_t* ptr = reinterpret_cast<const uint8_t*>(&request_sense_cmd);
-  absl::Span<const uint8_t> scsi_cmd = absl::MakeSpan(ptr, sizeof(1));
+  translator::Span<const uint8_t> scsi_cmd(ptr, sizeof(1));
   EXPECT_EQ(translator::RequestSenseToScsi(scsi_cmd, buffer),
             translator::StatusCode::kInvalidInput);
 }
@@ -62,8 +62,8 @@ TEST(RequestSense, ToNvmeBadControlByteNaca) {
   };
   uint32_t allocation_length = 0;
   const uint8_t* ptr = reinterpret_cast<const uint8_t*>(&request_sense_cmd);
-  absl::Span<const uint8_t> scsi_cmd =
-      absl::MakeSpan(ptr, sizeof(scsi::RequestSenseCommand));
+  translator::Span<const uint8_t> scsi_cmd =
+      translator::Span(ptr, sizeof(scsi::RequestSenseCommand));
   EXPECT_EQ(translator::RequestSenseToNvme(scsi_cmd, allocation_length),
             translator::StatusCode::kInvalidInput);
   EXPECT_EQ(allocation_length, 0);
@@ -71,12 +71,12 @@ TEST(RequestSense, ToNvmeBadControlByteNaca) {
 
 TEST(RequestSense, ToScsiDescriptor) {
   uint8_t buf[100];
-  absl::Span<uint8_t> buffer = buf;
+  translator::Span<uint8_t> buffer = buf;
   const scsi::RequestSenseCommand request_sense_cmd = {
       .desc = 1, .allocation_length = 100, .control_byte = {.naca = 0}};
   const uint8_t* ptr = reinterpret_cast<const uint8_t*>(&request_sense_cmd);
-  absl::Span<const uint8_t> scsi_cmd =
-      absl::MakeSpan(ptr, sizeof(scsi::RequestSenseCommand));
+  translator::Span<const uint8_t> scsi_cmd =
+      translator::Span(ptr, sizeof(scsi::RequestSenseCommand));
   translator::StatusCode status =
       translator::RequestSenseToScsi(scsi_cmd, buffer);
   EXPECT_EQ(status, translator::StatusCode::kSuccess);
@@ -91,12 +91,12 @@ TEST(RequestSense, ToScsiDescriptor) {
 
 TEST(RequestSense, ToScsiFixed) {
   uint8_t buf[100];
-  absl::Span<uint8_t> buffer = buf;
+  translator::Span<uint8_t> buffer = buf;
   const scsi::RequestSenseCommand request_sense_cmd = {
       .desc = 0, .allocation_length = 100, .control_byte = {.naca = 0}};
   const uint8_t* ptr = reinterpret_cast<const uint8_t*>(&request_sense_cmd);
-  absl::Span<const uint8_t> scsi_cmd =
-      absl::MakeSpan(ptr, sizeof(scsi::RequestSenseCommand));
+  translator::Span<const uint8_t> scsi_cmd =
+      translator::Span(ptr, sizeof(scsi::RequestSenseCommand));
   translator::StatusCode status =
       translator::RequestSenseToScsi(scsi_cmd, buffer);
   EXPECT_EQ(status, translator::StatusCode::kSuccess);

--- a/test/translator/translation_test.cc
+++ b/test/translator/translation_test.cc
@@ -25,7 +25,7 @@ namespace {
 TEST(Translation, ShouldHandleUnknownOpcode) {
   translator::Translation translation = {};
   uint8_t opc = 233;
-  absl::Span<const uint8_t> scsi_cmd = absl::MakeSpan(&opc, 1);
+  translator::Span<const uint8_t> scsi_cmd = translator::Span(&opc, 1);
   translator::BeginResponse resp = translation.Begin(scsi_cmd, 0);
   EXPECT_EQ(translator::ApiStatus::kSuccess, resp.status);
 }
@@ -33,22 +33,23 @@ TEST(Translation, ShouldHandleUnknownOpcode) {
 TEST(Translation, ShouldReturnInquirySuccess) {
   translator::Translation translation = {};
   uint8_t opc = static_cast<uint8_t>(scsi::OpCode::kInquiry);
-  absl::Span<const uint8_t> scsi_cmd = absl::MakeSpan(&opc, 1);
+  translator::Span<const uint8_t> scsi_cmd = translator::Span(&opc, 1);
   translator::BeginResponse resp = translation.Begin(scsi_cmd, 0);
   EXPECT_EQ(translator::ApiStatus::kSuccess, resp.status);
 }
 
 TEST(Translation, ShouldFailInvalidPipeline) {
   translator::Translation translation = {};
-  absl::Span<const nvme::GenericQueueEntryCpl> cpl_data;
-  absl::Span<uint8_t> buffer;
+  translator::Span<const nvme::GenericQueueEntryCpl> cpl_data;
+  translator::Span<uint8_t> buffer;
   translator::ApiStatus status = translation.Complete(cpl_data, buffer);
   EXPECT_EQ(translator::ApiStatus::kFailure, status);
 }
 
 TEST(Translation, ShouldReturnEmptyCmdSpan) {
   translator::Translation translation = {};
-  absl::Span<const nvme::GenericQueueEntryCmd> cmds = translation.GetNvmeCmds();
+  translator::Span<const nvme::GenericQueueEntryCmd> cmds =
+      translation.GetNvmeCmds();
   EXPECT_EQ(0, cmds.size());
 }
 


### PR DESCRIPTION
Closes #139 

Our library currently uses a number of includes that are not compatible with use in the Linux kernel. In particular, absl::Span has a great deal of dependencies on the STL.

This PR set out to remove all of these dependencies. Most notably, absl::Span was abandoned because of the large refactor time it would take to make it work without kernel-breaking stl features. A new Span class was written from the ground up to support our current use case.